### PR TITLE
fix(renovate): sync Cargo.lock on dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,8 @@
   "dependencyDashboard": false,
   "extends": [
     "config:recommended"
+  ],
+  "postUpdateOptions": [
+    "rustCargoBuildLockfile"
   ]
 }


### PR DESCRIPTION
Enable rustCargoBuildLockfile so Renovate runs cargo update after modifying Cargo.toml, keeping the lockfile in sync with version bumps.