### PR TITLE
fix(stale): exclude local-only branches from stale detection

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -98,17 +98,21 @@ pub fn stale_branches() -> AppResult<Vec<String>> {
     let merged_output = run(&["branch", "--format=%(refname:short)", "--merged"])?;
     let tracking_output = run(&[
         "for-each-ref",
-        "--format=%(refname:short)|%(upstream:track)",
+        "--format=%(refname:short) %(upstream) %(upstream:track)",
         "refs/heads/",
     ])?;
 
-    let mut gone = Vec::new();
     let mut has_upstream = Vec::new();
+    let mut gone = Vec::new();
     for line in tracking_output.lines() {
-        let (name, track) = line.split_once('|').unwrap_or((line, ""));
-        if track == "[gone]" {
+        let mut parts = line.split_whitespace();
+        let Some(name) = parts.next() else { continue };
+        if parts.next().is_none() {
+            continue; // local-only branch — no upstream
+        }
+        if line.ends_with("[gone]") {
             gone.push(name);
-        } else if !track.is_empty() {
+        } else {
             has_upstream.push(name);
         }
     }

--- a/src/git.rs
+++ b/src/git.rs
@@ -96,25 +96,26 @@ pub fn stale_branches() -> AppResult<Vec<String>> {
     let keep = kept_branches();
 
     let merged_output = run(&["branch", "--format=%(refname:short)", "--merged"])?;
-    let gone_output = run(&[
+    let tracking_output = run(&[
         "for-each-ref",
         "--format=%(refname:short) %(upstream:track)",
         "refs/heads/",
     ])?;
 
-    let gone: Vec<&str> = gone_output
-        .lines()
-        .filter_map(|line| {
-            if line.ends_with("[gone]") {
-                line.split_whitespace().next()
-            } else {
-                None
-            }
-        })
-        .collect();
+    let mut gone = Vec::new();
+    let mut has_upstream = Vec::new();
+    for line in tracking_output.lines() {
+        let name = line.split_whitespace().next().unwrap_or("");
+        if line.ends_with("[gone]") {
+            gone.push(name);
+        } else if name != line {
+            has_upstream.push(name);
+        }
+    }
 
     let mut branches: Vec<String> = merged_output
         .lines()
+        .filter(|b| has_upstream.contains(b))
         .chain(gone)
         .filter(|b| current.as_deref() != Some(*b) && !keep.iter().any(|k| k == b))
         .map(String::from)

--- a/src/git.rs
+++ b/src/git.rs
@@ -98,17 +98,17 @@ pub fn stale_branches() -> AppResult<Vec<String>> {
     let merged_output = run(&["branch", "--format=%(refname:short)", "--merged"])?;
     let tracking_output = run(&[
         "for-each-ref",
-        "--format=%(refname:short) %(upstream:track)",
+        "--format=%(refname:short)|%(upstream:track)",
         "refs/heads/",
     ])?;
 
     let mut gone = Vec::new();
     let mut has_upstream = Vec::new();
     for line in tracking_output.lines() {
-        let name = line.split_whitespace().next().unwrap_or("");
-        if line.ends_with("[gone]") {
+        let (name, track) = line.split_once('|').unwrap_or((line, ""));
+        if track == "[gone]" {
             gone.push(name);
-        } else if name != line {
+        } else if !track.is_empty() {
             has_upstream.push(name);
         }
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -225,3 +225,30 @@ fn local_only_branch_not_stale() {
         "local-only branch should not be considered stale, got: {stale:?}"
     );
 }
+
+#[test]
+fn merged_tracked_branch_is_stale() {
+    let _lock = CWD_LOCK.lock().unwrap();
+    let (_bare, work) = setup();
+
+    // Create a branch, push it, then merge into main.
+    // The upstream is in sync (not gone), but the branch is fully merged.
+    git(work.path(), &["checkout", "-b", "feature-done"]);
+    fs::write(work.path().join("feature.txt"), "done\n").unwrap();
+    git(work.path(), &["add", "feature.txt"]);
+    git(work.path(), &["commit", "-m", "feature"]);
+    git(work.path(), &["push", "-u", "origin", "feature-done"]);
+    git(work.path(), &["checkout", "main"]);
+    git(work.path(), &["merge", "feature-done"]);
+    git(work.path(), &["push", "origin", "main"]);
+
+    let original = std::env::current_dir().unwrap();
+    std::env::set_current_dir(work.path()).unwrap();
+    let stale = git_switch::git::stale_branches().unwrap();
+    std::env::set_current_dir(&original).unwrap();
+
+    assert!(
+        stale.contains(&"feature-done".to_string()),
+        "merged branch with upstream should be stale, got: {stale:?}"
+    );
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,7 +1,11 @@
 use std::fs;
 use std::path::Path;
 use std::process::{Command, Output};
+use std::sync::Mutex;
 use tempfile::TempDir;
+
+/// Guards tests that call library functions relying on process cwd.
+static CWD_LOCK: Mutex<()> = Mutex::new(());
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -195,5 +199,29 @@ fn diverged_branch_reports_error() {
     assert!(
         combined.contains("diverged"),
         "expected divergence message, got: {combined}"
+    );
+}
+
+#[test]
+fn local_only_branch_not_stale() {
+    let _lock = CWD_LOCK.lock().unwrap();
+    let (_bare, work) = setup();
+
+    // Create a local-only branch (never pushed) and merge it into main.
+    git(work.path(), &["checkout", "-b", "local-experiment"]);
+    fs::write(work.path().join("experiment.txt"), "try something\n").unwrap();
+    git(work.path(), &["add", "experiment.txt"]);
+    git(work.path(), &["commit", "-m", "experiment"]);
+    git(work.path(), &["checkout", "main"]);
+    git(work.path(), &["merge", "local-experiment"]);
+
+    let original = std::env::current_dir().unwrap();
+    std::env::set_current_dir(work.path()).unwrap();
+    let stale = git_switch::git::stale_branches().unwrap();
+    std::env::set_current_dir(&original).unwrap();
+
+    assert!(
+        !stale.contains(&"local-experiment".to_string()),
+        "local-only branch should not be considered stale, got: {stale:?}"
     );
 }


### PR DESCRIPTION
Only branches with a remote tracking branch are now considered stale when merged. Previously, git branch --merged included all reachable branches, causing purely local branches to be flagged for cleanup.