### PR TITLE
fix(release): use portable perl for in-place version bump

### DIFF
--- a/justfile
+++ b/justfile
@@ -46,7 +46,7 @@ release tag:
   set -e
   version="{{tag}}"
   version="${version#v}"
-  sed -i '' "s/^version = \".*\"/version = \"$version\"/" Cargo.toml
+  perl -i -pe "s/^version = \".*\"/version = \"$version\"/" Cargo.toml
   cargo check --quiet
   git add Cargo.toml Cargo.lock
   git commit -m "chore: bump version to $version"


### PR DESCRIPTION
## Summary
- Replace BSD-only `sed -i ''` with `perl -i -pe` in the `release` recipe so `just release` works on Linux as well as macOS.

## Test plan
- [x] Smoke-tested `perl -i -pe "s/^version = \".*\"/version = \"$version\"/"` against a sample `Cargo.toml` — version line updated, rest of file untouched.
- [ ] Verify `just release <tag>` runs cleanly on Linux on next release cut.

Closes #14