### PR TITLE
fix: restore cursor on early return via RAII guard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25,6 +34,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "console"
@@ -39,6 +54,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix",
+ "windows-sys",
+]
+
+[[package]]
 name = "dialoguer"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -49,6 +75,18 @@ dependencies = [
  "shell-words",
  "tempfile",
  "zeroize",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
 ]
 
 [[package]]
@@ -112,6 +150,7 @@ name = "git-switch"
 version = "1.0.7"
 dependencies = [
  "console",
+ "ctrlc",
  "dialoguer",
  "indicatif",
  "tempfile",
@@ -214,6 +253,33 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "once_cell"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 console = "0.16"
+ctrlc = "3"
 dialoguer = { version = "0.12", features = ["fuzzy-select"] }
 indicatif = "0.18"
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -4,6 +4,22 @@ use indicatif::ProgressBar;
 
 use crate::{AppResult, git};
 
+struct CursorGuard(Term);
+
+impl CursorGuard {
+    fn hide() -> Self {
+        let term = Term::stderr();
+        let _ = term.hide_cursor();
+        Self(term)
+    }
+}
+
+impl Drop for CursorGuard {
+    fn drop(&mut self) {
+        let _ = self.0.show_cursor();
+    }
+}
+
 pub fn run(target: Option<&str>) -> AppResult<()> {
     let old_branch = git::current_branch()?;
 
@@ -46,15 +62,17 @@ fn switch_and_update(target: &str, old_branch: Option<&str>) -> AppResult<()> {
         git::checkout(target)?;
     }
 
-    let spinner = ProgressBar::new_spinner().with_message(format!("Updating {target}…"));
-    eprint!("\x1b[?25l"); // hide cursor
-    spinner.enable_steady_tick(std::time::Duration::from_millis(80));
+    let merge_result = {
+        let spinner = ProgressBar::new_spinner().with_message(format!("Updating {target}…"));
+        let _cursor_guard = CursorGuard::hide();
+        spinner.enable_steady_tick(std::time::Duration::from_millis(80));
 
-    let _ = git::fetch();
-    let merge_result = git::fast_forward_merge(target)?;
+        let _ = git::fetch();
+        let result = git::fast_forward_merge(target)?;
 
-    spinner.finish_and_clear();
-    eprint!("\x1b[?25h"); // show cursor
+        spinner.finish_and_clear();
+        result
+    };
     report_update(merge_result)?;
 
     prompt_delete_stale_branches(if already_on_target { None } else { old_branch })?;
@@ -163,7 +181,7 @@ fn multi_select(prompt: &str, items: &[String], defaults: &[bool]) -> AppResult<
     let mut cursor = 0usize;
     let header = format!("{} {}", style("?").green().bold(), style(prompt).bold());
 
-    eprint!("\x1b[?25l"); // hide cursor
+    let _cursor_guard = CursorGuard::hide();
 
     let draw = |cursor: usize, selected: &[bool]| -> usize {
         let width = term.size().1 as usize;
@@ -197,7 +215,6 @@ fn multi_select(prompt: &str, items: &[String], defaults: &[bool]) -> AppResult<
             Key::Enter => break,
             Key::Escape => {
                 clear(drawn);
-                eprint!("\x1b[?25h"); // show cursor
                 return Ok(vec![]);
             }
             _ => continue,
@@ -206,8 +223,6 @@ fn multi_select(prompt: &str, items: &[String], defaults: &[bool]) -> AppResult<
         clear(drawn);
         drawn = draw(cursor, &selected);
     }
-
-    eprint!("\x1b[?25h"); // show cursor
 
     Ok(selected
         .iter()

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,12 @@ fn main() {
     };
 
     if let Err(e) = git_switch::app::run(target.as_deref()) {
+        if e.downcast_ref::<std::io::Error>()
+            .is_some_and(|io| io.kind() == std::io::ErrorKind::Interrupted)
+        {
+            let _ = console::Term::stderr().show_cursor();
+            process::exit(130);
+        }
         eprintln!("error: {e}");
         process::exit(1);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,11 @@
 use std::process;
 
 fn main() {
+    let _ = ctrlc::set_handler(|| {
+        let _ = console::Term::stderr().show_cursor();
+        process::exit(130);
+    });
+
     let target = match std::env::args().nth(1).as_deref() {
         Some("--help" | "-h") => {
             println!("Usage: git-switch [<branch>]");


### PR DESCRIPTION
## Summary

- Introduce a `CursorGuard` RAII type wrapping `console::Term` that hides the cursor on construction and shows it on `Drop`.
- Replace five manual `\x1b[?25l/h` escape pairs in `switch_and_update` and `multi_select` with guard bindings.
- Drop ordering now restores the cursor on early-return paths — notably `git::fast_forward_merge(target)?` in `switch_and_update` and `term.read_key()?` in the multi-select loop — both reachable in normal use.

Uses `Term::hide_cursor` / `show_cursor` instead of raw escape sequences for cross-platform safety. Caveat: with `panic = "abort"`, drops still don't run on panic or SIGINT — same as before.

## Test plan

- [x] `just test` (8 integration tests pass)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] Manually verify cursor restoration after Ctrl+C during multi-select
- [x] Manually verify cursor restoration after `fast_forward_merge` divergence error

Closes #12