### PR TITLE
fix: warn when fetch fails instead of reporting stale state

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -62,18 +62,26 @@ fn switch_and_update(target: &str, old_branch: Option<&str>) -> AppResult<()> {
         git::checkout(target)?;
     }
 
-    let merge_result = {
+    let (fetch_ok, merge_result) = {
         let spinner = ProgressBar::new_spinner().with_message(format!("Updating {target}…"));
         let _cursor_guard = CursorGuard::hide();
         spinner.enable_steady_tick(std::time::Duration::from_millis(80));
 
-        let _ = git::fetch();
-        let result = git::fast_forward_merge(target)?;
+        let fetch_ok = git::fetch().unwrap_or(false);
+        let result = git::fast_forward_merge(target);
 
         spinner.finish_and_clear();
-        result
+        (fetch_ok, result)
     };
-    report_update(merge_result)?;
+
+    if !fetch_ok {
+        eprintln!(
+            "{} fetch failed; results may be stale",
+            style("!").yellow().bold()
+        );
+    }
+
+    report_update(merge_result?)?;
 
     prompt_delete_stale_branches(if already_on_target { None } else { old_branch })?;
 


### PR DESCRIPTION
## Summary
- Capture the result of `git::fetch()` and emit a yellow `!` warning when fetch fails, so users aren't misled into thinking they're up to date with origin.
- Restructure the spinner block to a tuple return so the warning fires regardless of whether `fast_forward_merge` errors afterwards.
- Offline use still works — fetch failure remains non-fatal.

## Test plan
- [x] `just test` (8 integration tests pass)
- [ ] Manual: simulate fetch failure (e.g. block network or point origin at a bad URL) and confirm warning prints once, spinner clears cleanly, and the merge step still reports based on local refs.
- [x] Manual: normal online flow — confirm no warning appears.

Closes #13