### PR TITLE
fix: only show conflict guidance when stash pop actually conflicts

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -44,11 +44,19 @@ pub fn run(target: Option<&str>) -> AppResult<()> {
             eprintln!("Switching back to {old} and restoring stashed changes.");
             let _ = git::checkout(old);
         }
-        if let Err(e) = git::stash_pop() {
-            eprintln!("error: {e}");
-            eprintln!(
-                "Conflicts detected. Resolve them, then run `git stash drop` to clean up the stash entry."
-            );
+        match git::stash_pop() {
+            Ok(git::StashPopOutcome::Clean) => {}
+            Ok(git::StashPopOutcome::Conflict) => {
+                eprintln!(
+                    "Conflicts detected restoring stashed changes. Resolve them, then run `git stash drop` to clean up the stash entry."
+                );
+            }
+            Err(e) => {
+                eprintln!("error: {e}");
+                eprintln!(
+                    "Stash pop failed. Inspect `git status` and `git stash list` to recover manually."
+                );
+            }
         }
     }
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -10,6 +10,11 @@ pub enum MergeResult {
     NoRemote,
 }
 
+pub enum StashPopOutcome {
+    Clean,
+    Conflict,
+}
+
 pub fn current_branch() -> AppResult<Option<String>> {
     let output = run(&["branch", "--show-current"])?;
     let name = output.trim().to_string();
@@ -49,19 +54,25 @@ pub fn stash_push() -> AppResult<()> {
     Ok(())
 }
 
-pub fn stash_pop() -> AppResult<()> {
+pub fn stash_pop() -> AppResult<StashPopOutcome> {
     let output = Command::new("git").args(["stash", "pop"]).output()?;
-    if !output.status.success() {
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        let detail = if stdout.trim().is_empty() {
-            stderr.trim().to_string()
-        } else {
-            stdout.trim().to_string()
-        };
-        return Err(format!("git stash pop: {detail}").into());
+    if output.status.success() {
+        return Ok(StashPopOutcome::Clean);
     }
-    Ok(())
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if stdout.contains("CONFLICT") || stderr.contains("CONFLICT") {
+        return Ok(StashPopOutcome::Conflict);
+    }
+
+    let stdout_trimmed = stdout.trim();
+    let detail = if stdout_trimmed.is_empty() {
+        stderr.trim()
+    } else {
+        stdout_trimmed
+    };
+    Err(format!("git stash pop: {detail}").into())
 }
 
 pub fn checkout(branch: &str) -> AppResult<()> {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -155,8 +155,8 @@ fn stash_pop_conflict_shows_guidance() {
 
     let stderr = stderr_str(&output);
     assert!(
-        stderr.contains("git stash pop"),
-        "expected stash guidance in stderr, got: {stderr}"
+        stderr.contains("Conflicts detected"),
+        "expected conflict-specific guidance in stderr, got: {stderr}"
     );
 
     // The stash should still be present for manual recovery.


### PR DESCRIPTION
## Summary
- `git::stash_pop` now distinguishes conflicts from other failures by checking for the `CONFLICT` marker in git's output
- `app.rs` prints conflict-specific guidance only on actual conflicts, and a neutral "inspect git status / git stash list" message on other failures (e.g. dirty-worktree errors via the failed-checkout rollback path)
- Updated the existing conflict integration test to assert the new conflict-specific message; non-conflict failure path verified manually (untracked-file collision triggers the neutral branch)

## Test plan
- [x] `just test` passes (8/8)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] Manually verified: real conflict → "Conflicts detected restoring stashed changes."
- [x] Manually verified: untracked-file collision (no `CONFLICT` in output) → "Stash pop failed. Inspect \`git status\` and \`git stash list\` to recover manually."

Closes #10