### PR TITLE
fix: surface git stderr when fetch fails

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -70,23 +70,27 @@ fn switch_and_update(target: &str, old_branch: Option<&str>) -> AppResult<()> {
         git::checkout(target)?;
     }
 
-    let (fetch_ok, merge_result) = {
+    let (fetch_outcome, merge_result) = {
         let spinner = ProgressBar::new_spinner().with_message(format!("Updating {target}…"));
         let _cursor_guard = CursorGuard::hide();
         spinner.enable_steady_tick(std::time::Duration::from_millis(80));
 
-        let fetch_ok = git::fetch().unwrap_or(false);
+        let fetch_outcome =
+            git::fetch().unwrap_or_else(|e| git::FetchOutcome::Failed(e.to_string()));
         let result = git::fast_forward_merge(target);
 
         spinner.finish_and_clear();
-        (fetch_ok, result)
+        (fetch_outcome, result)
     };
 
-    if !fetch_ok {
+    if let git::FetchOutcome::Failed(detail) = &fetch_outcome {
         eprintln!(
             "{} fetch failed; results may be stale",
             style("!").yellow().bold()
         );
+        for line in detail.lines() {
+            eprintln!("  {line}");
+        }
     }
 
     report_update(merge_result?)?;

--- a/src/git.rs
+++ b/src/git.rs
@@ -15,6 +15,11 @@ pub enum StashPopOutcome {
     Conflict,
 }
 
+pub enum FetchOutcome {
+    Ok,
+    Failed(String),
+}
+
 pub fn current_branch() -> AppResult<Option<String>> {
     let output = run(&["branch", "--show-current"])?;
     let name = output.trim().to_string();
@@ -100,12 +105,15 @@ pub fn checkout(branch: &str) -> AppResult<()> {
     Ok(())
 }
 
-pub fn fetch() -> AppResult<bool> {
-    let status = Command::new("git")
+pub fn fetch() -> AppResult<FetchOutcome> {
+    let output = Command::new("git")
         .args(["fetch", "--quiet", "--prune", "origin"])
-        .stderr(std::process::Stdio::null())
-        .status()?;
-    Ok(status.success())
+        .output()?;
+    if output.status.success() {
+        return Ok(FetchOutcome::Ok);
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    Ok(FetchOutcome::Failed(stderr))
 }
 
 pub fn fast_forward_merge(branch: &str) -> AppResult<MergeResult> {


### PR DESCRIPTION
## Summary
- `git::fetch` now captures stderr via `.output()` and returns a `FetchOutcome::{Ok, Failed(String)}` enum instead of a bare `bool`.
- Caller prints each stderr line indented under the existing `! fetch failed; results may be stale` warning, so users hitting auth/network/hook failures can see the underlying `fatal: …` message.
- Spawn errors are folded into the same `Failed` variant so they're not silently dropped either.

## Test plan
- [x] `just test` — 8/8 integration tests pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] Manually verified against an unreachable remote — output now includes `fatal: unable to access … Could not resolve host` under the warning

Closes #25