### PR TITLE
fix: avoid usize underflow in multi_select arrow-down guard

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -228,7 +228,7 @@ fn multi_select(prompt: &str, items: &[String], defaults: &[bool]) -> AppResult<
     loop {
         match term.read_key()? {
             Key::ArrowUp if cursor > 0 => cursor -= 1,
-            Key::ArrowDown if cursor < items.len() - 1 => cursor += 1,
+            Key::ArrowDown if cursor + 1 < items.len() => cursor += 1,
             Key::Char(' ') => selected[cursor] = !selected[cursor],
             Key::ArrowRight => selected.fill(true),
             Key::ArrowLeft => selected.fill(false),


### PR DESCRIPTION
## Summary
- Rewrites the `ArrowDown` guard in `multi_select` from `cursor < items.len() - 1` to `cursor + 1 < items.len()` so empty input is benign at the source rather than relying on the caller to guard.

## Test plan
- [x] `just test` (8 integration tests pass)
- [x] Visual review of the diff — semantically identical for non-empty inputs.

Closes #26