### PR TITLE
chore: add publish metadata to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,12 @@
 name = "git-switch"
 version = "1.0.7"
 edition = "2024"
+categories = ["command-line-utilities", "development-tools"]
+description = "Interactive Git branch switcher with merged-branch cleanup"
+keywords = ["branch", "cli", "git"]
+license = "MIT"
+readme = "README.md"
+repository = "https://github.com/brzzdev/git-switch"
 
 [dependencies]
 console = "0.16"


### PR DESCRIPTION
## Summary
- Add `description`, `license`, `repository`, `readme`, `keywords`, and `categories` to `[package]`.
- Values follow the issue's suggested set; `keywords` and `categories` are alphabetised per project convention.
- License documents the MIT intent already stated in the README; useful for `cargo install --git` users who currently see no description.

## Test plan
- [x] `cargo metadata --no-deps --format-version 1` parses successfully and reflects all six new fields.
- [x] `cargo check` passes.

Closes #20