### PR TITLE
build: enforce clippy lints across both crates via Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,11 @@ indicatif = "0.18"
 [dev-dependencies]
 tempfile = "3"
 
+[lints.clippy]
+all = { level = "warn", priority = -1 }
+pedantic = { level = "warn", priority = -1 }
+missing_errors_doc = "allow"
+
 [profile.release]
 opt-level = "z"
 lto = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,3 @@
-#![warn(clippy::all, clippy::pedantic)]
-#![allow(clippy::missing_errors_doc)]
-
 pub mod app;
 pub mod git;
 


### PR DESCRIPTION
## Summary
- Move `clippy::all` / `clippy::pedantic` warnings and the `missing_errors_doc` allow from inner attributes in `src/lib.rs` to a workspace-level `[lints.clippy]` table in `Cargo.toml`.
- The previous setup only applied to the library crate — `src/main.rs` is a separate crate and inherited nothing, so any pedantic-tier issue introduced there would slip past `cargo clippy`.
- Lint groups (`all`, `pedantic`) carry `priority = -1` so the individual `missing_errors_doc` allow can override them; clippy's own `lint_groups_priority` lint requires this.

## Test plan
- [x] \`cargo clippy --all-targets -- -D warnings\` passes cleanly (lib + bin)
- [x] \`just test\` — all 8 integration tests pass
- [x] No latent pedantic issues surfaced in \`main.rs\` (existing code was already clean)

Closes #23