### PR TITLE
fix: exit cleanly when branch selection is cancelled

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -25,7 +25,10 @@ pub fn run(target: Option<&str>) -> AppResult<()> {
 
     let target = match target {
         Some(name) => name.to_string(),
-        None => select_branch(old_branch.as_deref())?,
+        None => match select_branch(old_branch.as_deref())? {
+            Some(t) => t,
+            None => return Ok(()),
+        },
     };
 
     let stashed = if git::has_tracked_changes()? {
@@ -117,7 +120,7 @@ fn report_update(result: git::MergeResult) -> AppResult<()> {
     Ok(())
 }
 
-fn select_branch(current: Option<&str>) -> AppResult<String> {
+fn select_branch(current: Option<&str>) -> AppResult<Option<String>> {
     let local = git::local_branches()?;
     let remote_only = git::remote_only_branches(&local).unwrap_or_default();
 
@@ -141,9 +144,9 @@ fn select_branch(current: Option<&str>) -> AppResult<String> {
         .with_prompt("Switch to")
         .items(&display)
         .default(default)
-        .interact()?;
+        .interact_opt()?;
 
-    Ok(branches[selection].1.clone())
+    Ok(selection.map(|i| branches[i].1.clone()))
 }
 
 fn prompt_delete_stale_branches(old_branch: Option<&str>) -> AppResult<()> {

--- a/src/app.rs
+++ b/src/app.rs
@@ -144,7 +144,8 @@ fn select_branch(current: Option<&str>) -> AppResult<Option<String>> {
         .with_prompt("Switch to")
         .items(&display)
         .default(default)
-        .interact_opt()?;
+        .interact_opt()
+        .map_err(std::io::Error::from)?;
 
     Ok(selection.map(|i| branches[i].1.clone()))
 }


### PR DESCRIPTION
## Summary
- Pressing Esc at the `Switch to` fuzzy prompt printed `error: IO error: read interrupted` and exited 1.
- Root cause: `FuzzySelect::interact()` returns a `dialoguer::Error` (not a `std::io::Error`), so the existing `downcast_ref::<std::io::Error>()` guard in `main.rs` missed it and fell through to `eprintln!("error: {e}")`. `dialoguer::Error`'s Display is `"IO error: {inner}"`, hence the message.
- Switch to `interact_opt()`, which returns `Ok(None)` on Esc; `run()` returns `Ok(())` when no branch is chosen — silent clean exit, matching the existing `multi_select` Esc behaviour.

## Test plan
- [x] `just test` — all 8 integration tests pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] Manual: run `git-switch`, press Esc at the prompt → exits 0 with no stderr noise
- [x] Manual: run `git-switch`, pick a branch → still works as before

## Note
Touches the same function as #31 (BranchOption refactor). Whichever lands first, the other will need a small rebase.