### PR TITLE
fix(git): respect configured remote instead of hardcoding origin

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -22,10 +22,11 @@ impl Drop for CursorGuard {
 
 pub fn run(target: Option<&str>) -> AppResult<()> {
     let old_branch = git::current_branch()?;
+    let remote = git::current_remote(old_branch.as_deref());
 
     let target = match target {
         Some(name) => name.to_string(),
-        None => match select_branch(old_branch.as_deref())? {
+        None => match select_branch(old_branch.as_deref(), &remote)? {
             Some(t) => t,
             None => return Ok(()),
         },
@@ -38,7 +39,7 @@ pub fn run(target: Option<&str>) -> AppResult<()> {
         false
     };
 
-    let result = switch_and_update(&target, old_branch.as_deref());
+    let result = switch_and_update(&target, old_branch.as_deref(), &remote);
 
     if stashed {
         if result.is_err()
@@ -66,7 +67,7 @@ pub fn run(target: Option<&str>) -> AppResult<()> {
     result
 }
 
-fn switch_and_update(target: &str, old_branch: Option<&str>) -> AppResult<()> {
+fn switch_and_update(target: &str, old_branch: Option<&str>, remote: &str) -> AppResult<()> {
     let already_on_target = old_branch.is_some_and(|b| b == target);
 
     if !already_on_target {
@@ -79,8 +80,8 @@ fn switch_and_update(target: &str, old_branch: Option<&str>) -> AppResult<()> {
         spinner.enable_steady_tick(std::time::Duration::from_millis(80));
 
         let fetch_outcome =
-            git::fetch().unwrap_or_else(|e| git::FetchOutcome::Failed(e.to_string()));
-        let result = git::fast_forward_merge(target);
+            git::fetch(remote).unwrap_or_else(|e| git::FetchOutcome::Failed(e.to_string()));
+        let result = git::fast_forward_merge(target, remote);
 
         spinner.finish_and_clear();
         (fetch_outcome, result)
@@ -96,14 +97,14 @@ fn switch_and_update(target: &str, old_branch: Option<&str>) -> AppResult<()> {
         }
     }
 
-    report_update(merge_result?)?;
+    report_update(merge_result?, remote)?;
 
-    prompt_delete_stale_branches(if already_on_target { None } else { old_branch })?;
+    prompt_delete_stale_branches(if already_on_target { None } else { old_branch }, remote)?;
 
     Ok(())
 }
 
-fn report_update(result: git::MergeResult) -> AppResult<()> {
+fn report_update(result: git::MergeResult, remote: &str) -> AppResult<()> {
     match result {
         git::MergeResult::UpToDate => println!("Already up to date."),
         git::MergeResult::Pulled(1) => println!("Pulled 1 commit."),
@@ -111,8 +112,8 @@ fn report_update(result: git::MergeResult) -> AppResult<()> {
         git::MergeResult::NoRemote => println!("No remote tracking branch."),
         git::MergeResult::Diverged(branch) => {
             eprintln!(
-                "Local branch has diverged from origin/{branch}.\n\
-                 Run `git rebase origin/{branch}` or `git merge origin/{branch}` to reconcile."
+                "Local branch has diverged from {remote}/{branch}.\n\
+                 Run `git rebase {remote}/{branch}` or `git merge {remote}/{branch}` to reconcile."
             );
             return Err("branch diverged from remote".into());
         }
@@ -133,17 +134,17 @@ impl BranchOption {
         }
     }
 
-    fn remote(name: String) -> Self {
+    fn remote(name: String, remote: &str) -> Self {
         Self {
-            display: format!("origin/{name}"),
+            display: format!("{remote}/{name}"),
             checkout: name,
         }
     }
 }
 
-fn select_branch(current: Option<&str>) -> AppResult<Option<String>> {
+fn select_branch(current: Option<&str>, remote: &str) -> AppResult<Option<String>> {
     let local = git::local_branches()?;
-    let remote_only = git::remote_only_branches(&local).unwrap_or_default();
+    let remote_only = git::remote_only_branches(&local, remote).unwrap_or_default();
 
     if local.is_empty() && remote_only.is_empty() {
         return Err("no branches found".into());
@@ -152,7 +153,11 @@ fn select_branch(current: Option<&str>) -> AppResult<Option<String>> {
     let branches: Vec<BranchOption> = local
         .into_iter()
         .map(BranchOption::local)
-        .chain(remote_only.into_iter().map(BranchOption::remote))
+        .chain(
+            remote_only
+                .into_iter()
+                .map(|name| BranchOption::remote(name, remote)),
+        )
         .collect();
 
     let display: Vec<&str> = branches.iter().map(|b| b.display.as_str()).collect();
@@ -171,8 +176,8 @@ fn select_branch(current: Option<&str>) -> AppResult<Option<String>> {
     Ok(selection.map(|i| branches[i].checkout.clone()))
 }
 
-fn prompt_delete_stale_branches(old_branch: Option<&str>) -> AppResult<()> {
-    let all_stale = git::stale_branches()?;
+fn prompt_delete_stale_branches(old_branch: Option<&str>, remote: &str) -> AppResult<()> {
+    let all_stale = git::stale_branches(remote)?;
     if all_stale.is_empty() {
         return Ok(());
     }

--- a/src/git.rs
+++ b/src/git.rs
@@ -26,23 +26,48 @@ pub fn current_branch() -> AppResult<Option<String>> {
     Ok(if name.is_empty() { None } else { Some(name) })
 }
 
+/// Resolves the remote name to use for fetch, merge, and default-branch
+/// detection. Prefers `branch.<current>.remote`, then the sole configured
+/// remote, falling back to `origin`.
+#[must_use]
+pub fn current_remote(current: Option<&str>) -> String {
+    if let Some(branch) = current
+        && let Ok(output) = run(&["config", "--get", &format!("branch.{branch}.remote")])
+    {
+        let name = output.trim();
+        // `.` means push to the local repo — useless for fetch/merge.
+        if !name.is_empty() && name != "." {
+            return name.to_string();
+        }
+    }
+
+    if let Ok(output) = run(&["remote"]) {
+        let mut remotes = output.lines().filter(|l| !l.is_empty());
+        if let Some(only) = remotes.next()
+            && remotes.next().is_none()
+        {
+            return only.to_string();
+        }
+    }
+
+    "origin".to_string()
+}
+
 pub fn local_branches() -> AppResult<Vec<String>> {
     let output = run(&["branch", "--format=%(refname:short)"])?;
     let branches = output.lines().map(String::from).collect();
     Ok(branches)
 }
 
-pub fn remote_only_branches(local: &[String]) -> AppResult<Vec<String>> {
-    let output = run(&[
-        "for-each-ref",
-        "--format=%(refname:short)",
-        "refs/remotes/origin/",
-    ])?;
+pub fn remote_only_branches(local: &[String], remote: &str) -> AppResult<Vec<String>> {
+    let prefix = format!("refs/remotes/{remote}/");
+    let strip = format!("{remote}/");
+    let output = run(&["for-each-ref", "--format=%(refname:short)", &prefix])?;
     let locals: HashSet<&str> = local.iter().map(String::as_str).collect();
     let branches = output
         .lines()
         .filter(|r| !r.ends_with("/HEAD"))
-        .filter_map(|r| r.strip_prefix("origin/"))
+        .filter_map(|r| r.strip_prefix(&strip))
         .filter(|name| !locals.contains(name))
         .map(String::from)
         .collect();
@@ -105,9 +130,9 @@ pub fn checkout(branch: &str) -> AppResult<()> {
     Ok(())
 }
 
-pub fn fetch() -> AppResult<FetchOutcome> {
+pub fn fetch(remote: &str) -> AppResult<FetchOutcome> {
     let output = Command::new("git")
-        .args(["fetch", "--quiet", "--prune", "origin"])
+        .args(["fetch", "--quiet", "--prune", remote])
         .output()?;
     if output.status.success() {
         return Ok(FetchOutcome::Ok);
@@ -116,8 +141,8 @@ pub fn fetch() -> AppResult<FetchOutcome> {
     Ok(FetchOutcome::Failed(stderr))
 }
 
-pub fn fast_forward_merge(branch: &str) -> AppResult<MergeResult> {
-    let remote_ref = format!("origin/{branch}");
+pub fn fast_forward_merge(branch: &str, remote: &str) -> AppResult<MergeResult> {
+    let remote_ref = format!("{remote}/{branch}");
 
     let has_remote = Command::new("git")
         .args(["rev-parse", "--verify", &remote_ref])
@@ -151,9 +176,9 @@ pub fn fast_forward_merge(branch: &str) -> AppResult<MergeResult> {
     Ok(MergeResult::Pulled(count))
 }
 
-pub fn stale_branches() -> AppResult<Vec<String>> {
+pub fn stale_branches(remote: &str) -> AppResult<Vec<String>> {
     let current = current_branch()?;
-    let keep = kept_branches();
+    let keep = kept_branches(remote);
 
     let merged_output = run(&["branch", "--format=%(refname:short)", "--merged"])?;
     let refs_output = run(&[
@@ -206,21 +231,23 @@ pub fn stale_branches() -> AppResult<Vec<String>> {
     Ok(branches)
 }
 
-fn default_branch() -> Option<String> {
-    if let Ok(output) = run(&["symbolic-ref", "refs/remotes/origin/HEAD"]) {
+fn default_branch(remote: &str) -> Option<String> {
+    let head_ref = format!("refs/remotes/{remote}/HEAD");
+    let prefix = format!("refs/remotes/{remote}/");
+    if let Ok(output) = run(&["symbolic-ref", &head_ref]) {
         let trimmed = output.trim();
-        if let Some(name) = trimmed.strip_prefix("refs/remotes/origin/") {
+        if let Some(name) = trimmed.strip_prefix(prefix.as_str()) {
             return Some(name.to_string());
         }
     }
     None
 }
 
-fn kept_branches() -> HashSet<String> {
+fn kept_branches(remote: &str) -> HashSet<String> {
     let mut kept: HashSet<String> = run(&["config", "--get-all", "git-switch.keep"])
         .map(|o| o.lines().map(String::from).collect())
         .unwrap_or_default();
-    if let Some(default) = default_branch() {
+    if let Some(default) = default_branch(remote) {
         kept.insert(default);
     }
     kept

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -40,6 +40,10 @@ fn git_switch(dir: &Path, branch: &str) -> Output {
 
 /// Create a bare "remote" and a working clone with one commit on `main`.
 fn setup() -> (TempDir, TempDir) {
+    setup_with_remote("origin")
+}
+
+fn setup_with_remote(remote: &str) -> (TempDir, TempDir) {
     let bare = TempDir::new().unwrap();
     let work = TempDir::new().unwrap();
 
@@ -48,24 +52,28 @@ fn setup() -> (TempDir, TempDir) {
     git(work.path(), &["init", "-b", "main"]);
     git(
         work.path(),
-        &["remote", "add", "origin", bare.path().to_str().unwrap()],
+        &["remote", "add", remote, bare.path().to_str().unwrap()],
     );
 
     fs::write(work.path().join("file.txt"), "hello\n").unwrap();
     git(work.path(), &["add", "file.txt"]);
     git(work.path(), &["commit", "-m", "initial"]);
-    git(work.path(), &["push", "-u", "origin", "main"]);
+    git(work.path(), &["push", "-u", remote, "main"]);
 
     (bare, work)
 }
 
-/// Push a commit to `origin/main` that the working tree doesn't have.
+/// Push a commit to `<remote>/main` that the working tree doesn't have.
 /// Works by committing locally, pushing, then rewinding.
 fn push_upstream_change(work: &Path, file: &str, content: &str, msg: &str) {
+    push_upstream_change_to(work, "origin", file, content, msg);
+}
+
+fn push_upstream_change_to(work: &Path, remote: &str, file: &str, content: &str, msg: &str) {
     fs::write(work.join(file), content).unwrap();
     git(work, &["add", file]);
     git(work, &["commit", "-m", msg]);
-    git(work, &["push", "origin", "main"]);
+    git(work, &["push", remote, "main"]);
     git(work, &["reset", "--hard", "HEAD~1"]);
 }
 
@@ -218,7 +226,7 @@ fn local_only_branch_not_stale_right_after_merge() {
 
     let original = std::env::current_dir().unwrap();
     std::env::set_current_dir(work.path()).unwrap();
-    let stale = git_switch::git::stale_branches().unwrap();
+    let stale = git_switch::git::stale_branches("origin").unwrap();
     std::env::set_current_dir(&original).unwrap();
 
     assert!(
@@ -246,7 +254,7 @@ fn local_only_branch_stale_after_main_advances() {
 
     let original = std::env::current_dir().unwrap();
     std::env::set_current_dir(work.path()).unwrap();
-    let stale = git_switch::git::stale_branches().unwrap();
+    let stale = git_switch::git::stale_branches("origin").unwrap();
     std::env::set_current_dir(&original).unwrap();
 
     assert!(
@@ -273,7 +281,7 @@ fn merged_tracked_branch_is_stale() {
 
     let original = std::env::current_dir().unwrap();
     std::env::set_current_dir(work.path()).unwrap();
-    let stale = git_switch::git::stale_branches().unwrap();
+    let stale = git_switch::git::stale_branches("origin").unwrap();
     std::env::set_current_dir(&original).unwrap();
 
     assert!(
@@ -298,7 +306,7 @@ fn tracked_branch_without_unique_commits_not_stale() {
 
     let original = std::env::current_dir().unwrap();
     std::env::set_current_dir(work.path()).unwrap();
-    let stale = git_switch::git::stale_branches().unwrap();
+    let stale = git_switch::git::stale_branches("origin").unwrap();
     std::env::set_current_dir(&original).unwrap();
 
     assert!(
@@ -404,6 +412,56 @@ fn version_flag_prints_version() {
     assert_eq!(
         stdout_str(&output).trim(),
         format!("git-switch {}", env!("CARGO_PKG_VERSION"))
+    );
+}
+
+#[test]
+fn non_origin_remote_pulls_via_branch_config() {
+    let (_bare, work) = setup_with_remote("upstream");
+
+    push_upstream_change_to(
+        work.path(),
+        "upstream",
+        "file.txt",
+        "updated\n",
+        "upstream change",
+    );
+
+    let output = git_switch(work.path(), "main");
+
+    assert!(output.status.success(), "stderr: {}", stderr_str(&output));
+    assert!(
+        stdout_str(&output).contains("Pulled 1 commit"),
+        "stdout: {}",
+        stdout_str(&output)
+    );
+
+    let content = fs::read_to_string(work.path().join("file.txt")).unwrap();
+    assert_eq!(content, "updated\n");
+}
+
+#[test]
+fn non_origin_remote_detects_stale_branch() {
+    let _lock = CWD_LOCK.lock().unwrap();
+    let (_bare, work) = setup_with_remote("upstream");
+
+    git(work.path(), &["checkout", "-b", "feature-done"]);
+    fs::write(work.path().join("feature.txt"), "done\n").unwrap();
+    git(work.path(), &["add", "feature.txt"]);
+    git(work.path(), &["commit", "-m", "feature"]);
+    git(work.path(), &["push", "-u", "upstream", "feature-done"]);
+    git(work.path(), &["checkout", "main"]);
+    git(work.path(), &["merge", "feature-done"]);
+    git(work.path(), &["push", "upstream", "main"]);
+
+    let original = std::env::current_dir().unwrap();
+    std::env::set_current_dir(work.path()).unwrap();
+    let stale = git_switch::git::stale_branches("upstream").unwrap();
+    std::env::set_current_dir(&original).unwrap();
+
+    assert!(
+        stale.contains(&"feature-done".to_string()),
+        "merged branch with upstream remote should be stale, got: {stale:?}"
     );
 }
 


### PR DESCRIPTION
## Summary
- Replaces hardcoded `origin` across `fetch`, `fast_forward_merge`, `remote_only_branches`, and `default_branch` with a resolved remote name threaded through the call chain.
- Adds `git::current_remote(current)` which prefers `branch.<current>.remote`, then the sole configured remote, then falls back to `origin`.
- UI display strings (`{remote}/{branch}`) and the divergence guidance message now use the resolved remote.

## Test plan
- [x] `just test` — 15/15 integration tests pass, including two new cases for non-`origin` remotes
- [x] `cargo clippy --all-targets` clean
- [x] Existing default-`origin` workflows unchanged (preserved by fallback)

Closes #21