### PR TITLE
fix(git): take only the first line of branch.<name>.remote

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -33,12 +33,12 @@ pub fn current_branch() -> AppResult<Option<String>> {
 pub fn current_remote(current: Option<&str>) -> String {
     if let Some(branch) = current
         && let Ok(output) = run(&["config", "--get", &format!("branch.{branch}.remote")])
-    {
-        let name = output.trim();
+        && let Some(name) = output.lines().next().map(str::trim)
+        && !name.is_empty()
         // `.` means push to the local repo — useless for fetch/merge.
-        if !name.is_empty() && name != "." {
-            return name.to_string();
-        }
+        && name != "."
+    {
+        return name.to_string();
     }
 
     if let Ok(output) = run(&["remote"]) {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -466,6 +466,24 @@ fn non_origin_remote_detects_stale_branch() {
 }
 
 #[test]
+fn current_remote_handles_multiline_config_value() {
+    let _lock = CWD_LOCK.lock().unwrap();
+    let (_bare, work) = setup_with_remote("upstream");
+
+    git(
+        work.path(),
+        &["config", "branch.main.remote", "upstream\nstray"],
+    );
+
+    let original = std::env::current_dir().unwrap();
+    std::env::set_current_dir(work.path()).unwrap();
+    let remote = git_switch::git::current_remote(Some("main"));
+    std::env::set_current_dir(&original).unwrap();
+
+    assert_eq!(remote, "upstream");
+}
+
+#[test]
 fn detached_head_can_switch_to_branch() {
     let (_bare, work) = setup();
 


### PR DESCRIPTION
## Summary
- Harden `current_remote` against malformed `branch.<name>.remote` config values by taking only the first non-empty line. Multi-line values previously flowed verbatim into `git fetch`, `git merge`, and `for-each-ref refs/remotes/<name>/`.
- Add a regression test that injects a multi-line config value and asserts the resolved remote is the first line.

## Test plan
- [x] `just test` — 16/16 pass
- [x] Verified test fails without the fix and passes with it

Closes #38