### PR TITLE
refactor: replace Box<dyn Error> with thiserror enum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,6 +154,7 @@ dependencies = [
  "dialoguer",
  "indicatif",
  "tempfile",
+ "thiserror",
 ]
 
 [[package]]
@@ -422,6 +423,26 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ console = "0.16"
 ctrlc = "3"
 dialoguer = { version = "0.12", features = ["fuzzy-select"] }
 indicatif = "0.18"
+thiserror = "2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/app.rs
+++ b/src/app.rs
@@ -2,7 +2,7 @@ use console::{Key, Term, measure_text_width, style};
 use dialoguer::FuzzySelect;
 use indicatif::ProgressBar;
 
-use crate::{AppResult, git};
+use crate::{AppResult, Error, git};
 
 struct CursorGuard(Term);
 
@@ -115,7 +115,7 @@ fn report_update(result: git::MergeResult, remote: &str) -> AppResult<()> {
                 "Local branch has diverged from {remote}/{branch}.\n\
                  Run `git rebase {remote}/{branch}` or `git merge {remote}/{branch}` to reconcile."
             );
-            return Err("branch diverged from remote".into());
+            return Err(Error::Diverged);
         }
     }
     Ok(())
@@ -147,7 +147,7 @@ fn select_branch(current: Option<&str>, remote: &str) -> AppResult<Option<String
     let remote_only = git::remote_only_branches(&local, remote).unwrap_or_default();
 
     if local.is_empty() && remote_only.is_empty() {
-        return Err("no branches found".into());
+        return Err(Error::NoBranches);
     }
 
     let branches: Vec<BranchOption> = local

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::process::Command;
 
-use crate::AppResult;
+use crate::{AppResult, Error};
 
 pub enum MergeResult {
     UpToDate,
@@ -102,7 +102,10 @@ pub fn stash_pop() -> AppResult<StashPopOutcome> {
     } else {
         stdout_trimmed
     };
-    Err(format!("git stash pop: {detail}").into())
+    Err(Error::Git {
+        command: "stash pop".to_string(),
+        message: detail.to_string(),
+    })
 }
 
 pub fn checkout(branch: &str) -> AppResult<()> {
@@ -115,7 +118,10 @@ pub fn checkout(branch: &str) -> AppResult<()> {
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     if !stderr.contains("Submodule") || !stderr.contains("could not be updated") {
-        return Err(format!("git checkout: {}", stderr.trim()).into());
+        return Err(Error::Git {
+            command: "checkout".to_string(),
+            message: stderr.trim().to_string(),
+        });
     }
 
     // Submodule checkout failed — likely missing objects. Fetch inside
@@ -298,12 +304,10 @@ fn run(args: &[&str]) -> AppResult<String> {
     let output = Command::new("git").args(args).output()?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(format!(
-            "git {}: {}",
-            args.first().unwrap_or(&"<unknown>"),
-            stderr.trim()
-        )
-        .into());
+        return Err(Error::Git {
+            command: args.first().copied().unwrap_or("<unknown>").to_string(),
+            message: stderr.trim().to_string(),
+        });
     }
     Ok(String::from_utf8(output.stdout)?)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,25 @@
 pub mod app;
 pub mod git;
 
-pub type AppResult<T> = Result<T, Box<dyn std::error::Error + Send + Sync>>;
+pub type AppResult<T> = Result<T, Error>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("git {command}: {message}")]
+    Git { command: String, message: String },
+
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+
+    #[error("branch diverged from remote")]
+    Diverged,
+
+    #[error("no branches found")]
+    NoBranches,
+
+    #[error("invalid utf-8 from git: {0}")]
+    Utf8(#[from] std::string::FromUtf8Error),
+
+    #[error("invalid number from git: {0}")]
+    ParseInt(#[from] std::num::ParseIntError),
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,8 +20,8 @@ fn main() {
     };
 
     if let Err(e) = git_switch::app::run(target.as_deref()) {
-        if e.downcast_ref::<std::io::Error>()
-            .is_some_and(|io| io.kind() == std::io::ErrorKind::Interrupted)
+        if let git_switch::Error::Io(io) = &e
+            && io.kind() == std::io::ErrorKind::Interrupted
         {
             let _ = console::Term::stderr().show_cursor();
             process::exit(130);


### PR DESCRIPTION
## Summary
- Replace `pub type AppResult<T> = Result<T, Box<dyn std::error::Error + Send + Sync>>` with a `thiserror`-derived `Error` enum on the library surface.
- Variants: `Git { command, message }` for subprocess failures, `Io`/`Utf8`/`ParseInt` via `#[from]`, plus domain-specific `Diverged` and `NoBranches`.
- `main.rs` swaps `e.downcast_ref::<io::Error>()` for a typed `if let Error::Io(io) = &e` match arm.

Library consumers (integration tests, future users) can now pattern-match on failure modes instead of downcasting.

## Test plan
- [x] `just test` — all 16 integration tests pass
- [x] `cargo clippy --all-targets -- -D warnings` clean (pedantic enabled)
- [x] Ctrl-C during fuzzy-select still exits 130 (Interrupted path)

Closes #35