### PR TITLE
fix(git): use lossy utf-8 conversion for git output

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -309,5 +309,5 @@ fn run(args: &[&str]) -> AppResult<String> {
             message: stderr.trim().to_string(),
         });
     }
-    Ok(String::from_utf8(output.stdout)?)
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,9 +17,6 @@ pub enum Error {
     #[error("no branches found")]
     NoBranches,
 
-    #[error("invalid utf-8 from git: {0}")]
-    Utf8(#[from] std::string::FromUtf8Error),
-
     #[error("invalid number from git: {0}")]
     ParseInt(#[from] std::num::ParseIntError),
 }


### PR DESCRIPTION
## Summary
- `git::run()` now uses `String::from_utf8_lossy(...).into_owned()` instead of `String::from_utf8(...)?`, so non-UTF-8 git output (rare but legal) no longer surfaces a confusing `invalid utf-8 sequence` error to users.
- Removes the now-unused `Error::Utf8` variant.
- Matches how stderr is already handled throughout `src/git.rs`.

## Test plan
- [x] `just test` — all 16 integration tests pass

Closes #37