### PR TITLE
refactor(app): use Term::clear_last_lines in multi_select redraw

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -248,9 +248,7 @@ fn multi_select(prompt: &str, items: &[String], defaults: &[bool]) -> AppResult<
     };
 
     let clear = |n: usize| {
-        if n > 0 {
-            eprint!("\x1b[{n}F\x1b[J");
-        }
+        let _ = term.clear_last_lines(n);
     };
 
     let mut drawn = draw(cursor, &selected);


### PR DESCRIPTION
## Summary
- Replace the hand-rolled `\x1b[{n}F\x1b[J` escape in `multi_select` with `console::Term::clear_last_lines(n)`, the helper from a crate that's already imported and a `Term` already in scope.
- Drops the explicit `if n > 0` guard — `clear_last_lines` is a no-op for `n == 0`.
- Side benefit: no raw ANSI codes leak to stderr when it isn't a TTY (e.g. piped/redirected); `console` handles non-TTY and Windows correctly.

## Test plan
- [x] `just test` — all 16 integration tests pass
- [x] Manual: trigger the stale-branch deletion prompt and confirm arrow/space/→/← keys still redraw cleanly

Closes #36