### PR TITLE
feat(picker): group branches under sections; rebase on diverge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,19 +65,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dialoguer"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25f104b501bf2364e78d0d3974cbc774f738f5865306ed128e1e0d7499c0ad96"
-dependencies = [
- "console",
- "fuzzy-matcher",
- "shell-words",
- "tempfile",
- "zeroize",
-]
-
-[[package]]
 name = "dispatch2"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,15 +111,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
-name = "fuzzy-matcher"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
-dependencies = [
- "thread_local",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -151,7 +129,6 @@ version = "1.0.9"
 dependencies = [
  "console",
  "ctrlc",
- "dialoguer",
  "indicatif",
  "tempfile",
  "thiserror",
@@ -396,12 +373,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shell-words"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
-
-[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -443,15 +414,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "thread_local"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -687,12 +649,6 @@ dependencies = [
  "unicode-xid",
  "wasmparser",
 ]
-
-[[package]]
-name = "zeroize"
-version = "1.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ repository = "https://github.com/brzzdev/git-switch"
 [dependencies]
 console = "0.16"
 ctrlc = "3"
-dialoguer = { version = "0.12", features = ["fuzzy-select"] }
 indicatif = "0.18"
 thiserror = "2"
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,5 +1,6 @@
+use std::collections::HashSet;
+
 use console::{Key, Term, measure_text_width, style};
-use dialoguer::FuzzySelect;
 use indicatif::ProgressBar;
 
 use crate::{AppResult, Error, git};
@@ -121,28 +122,40 @@ fn report_update(result: git::MergeResult, remote: &str) -> AppResult<()> {
     Ok(())
 }
 
-struct BranchOption {
-    display: String,
-    checkout: String,
+#[derive(Clone)]
+struct Pick {
+    name: String,
+    is_current: bool,
+    remote_only: bool,
+    missing: bool,
 }
 
-impl BranchOption {
-    fn local(name: String) -> Self {
-        Self {
-            display: name.clone(),
-            checkout: name,
-        }
-    }
+struct Section {
+    heading: &'static str,
+    items: Vec<Pick>,
+}
 
-    fn remote(name: String, remote: &str) -> Self {
-        Self {
-            display: format!("{remote}/{name}"),
-            checkout: name,
-        }
-    }
+enum RowKind {
+    Heading(String),
+    Item(Pick),
+}
+
+struct RenderRow {
+    kind: RowKind,
+    section_idx: usize,
+}
+
+struct View {
+    rows: Vec<RenderRow>,
+    selectable: Vec<usize>,
 }
 
 fn select_branch(current: Option<&str>, remote: &str) -> AppResult<Option<String>> {
+    let sections = build_sections(current, remote)?;
+    pick(current, &sections)
+}
+
+fn build_sections(current: Option<&str>, remote: &str) -> AppResult<Vec<Section>> {
     let local = git::local_branches()?;
     let remote_only = git::remote_only_branches(&local, remote).unwrap_or_default();
 
@@ -150,30 +163,321 @@ fn select_branch(current: Option<&str>, remote: &str) -> AppResult<Option<String
         return Err(Error::NoBranches);
     }
 
-    let branches: Vec<BranchOption> = local
-        .into_iter()
-        .map(BranchOption::local)
-        .chain(
-            remote_only
-                .into_iter()
-                .map(|name| BranchOption::remote(name, remote)),
-        )
+    let pinned_names = git::pinned_branches(remote);
+    let local_set: HashSet<&str> = local.iter().map(String::as_str).collect();
+    let remote_set: HashSet<&str> = remote_only.iter().map(String::as_str).collect();
+    let pinned_set: HashSet<&str> = pinned_names.iter().map(String::as_str).collect();
+
+    let pinned_picks: Vec<Pick> = pinned_names
+        .iter()
+        .map(|name| {
+            let in_local = local_set.contains(name.as_str());
+            let in_remote = remote_set.contains(name.as_str());
+            Pick {
+                name: name.clone(),
+                is_current: current == Some(name.as_str()),
+                remote_only: !in_local && in_remote,
+                missing: !in_local && !in_remote,
+            }
+        })
         .collect();
 
-    let display: Vec<&str> = branches.iter().map(|b| b.display.as_str()).collect();
+    let local_picks: Vec<Pick> = local
+        .iter()
+        .filter(|b| !pinned_set.contains(b.as_str()))
+        .map(|b| Pick {
+            name: b.clone(),
+            is_current: current == Some(b.as_str()),
+            remote_only: false,
+            missing: false,
+        })
+        .collect();
 
-    let default = current
-        .and_then(|c| branches.iter().position(|b| b.checkout == c))
+    let remote_picks: Vec<Pick> = remote_only
+        .iter()
+        .filter(|b| !pinned_set.contains(b.as_str()))
+        .map(|b| Pick {
+            name: b.clone(),
+            is_current: false,
+            remote_only: false,
+            missing: false,
+        })
+        .collect();
+
+    let mut sections = Vec::new();
+    if !pinned_picks.is_empty() {
+        sections.push(Section {
+            heading: "Pinned",
+            items: pinned_picks,
+        });
+    }
+    if !local_picks.is_empty() {
+        sections.push(Section {
+            heading: "Local",
+            items: local_picks,
+        });
+    }
+    if !remote_picks.is_empty() {
+        sections.push(Section {
+            heading: "Remote",
+            items: remote_picks,
+        });
+    }
+    Ok(sections)
+}
+
+/// Case-insensitive subsequence match. Empty needle matches everything.
+fn fuzzy_match(needle: &str, haystack: &str) -> bool {
+    if needle.is_empty() {
+        return true;
+    }
+    let needle: String = needle.chars().flat_map(char::to_lowercase).collect();
+    let haystack: String = haystack.chars().flat_map(char::to_lowercase).collect();
+    let mut iter = haystack.chars();
+    'next: for nc in needle.chars() {
+        for hc in iter.by_ref() {
+            if hc == nc {
+                continue 'next;
+            }
+        }
+        return false;
+    }
+    true
+}
+
+fn build_view(sections: &[Section], filter: &str) -> View {
+    let mut rows: Vec<RenderRow> = Vec::new();
+    let mut selectable: Vec<usize> = Vec::new();
+
+    for (sec_idx, sec) in sections.iter().enumerate() {
+        let matching: Vec<&Pick> = sec
+            .items
+            .iter()
+            .filter(|p| fuzzy_match(filter, &p.name))
+            .collect();
+        if matching.is_empty() {
+            continue;
+        }
+        rows.push(RenderRow {
+            kind: RowKind::Heading(sec.heading.to_string()),
+            section_idx: sec_idx,
+        });
+        for pick in matching {
+            let idx = rows.len();
+            let is_selectable = !pick.missing;
+            rows.push(RenderRow {
+                kind: RowKind::Item(pick.clone()),
+                section_idx: sec_idx,
+            });
+            if is_selectable {
+                selectable.push(idx);
+            }
+        }
+    }
+
+    View { rows, selectable }
+}
+
+fn cursor_pick_name(view: &View, cursor: usize) -> Option<String> {
+    let &row_idx = view.selectable.get(cursor)?;
+    if let RowKind::Item(p) = &view.rows[row_idx].kind {
+        Some(p.name.clone())
+    } else {
+        None
+    }
+}
+
+fn selectable_position(view: &View, name: &str) -> Option<usize> {
+    view.selectable
+        .iter()
+        .position(|&i| matches!(&view.rows[i].kind, RowKind::Item(p) if p.name == name))
+}
+
+fn pick(current: Option<&str>, sections: &[Section]) -> AppResult<Option<String>> {
+    let term = Term::stderr();
+    let _cursor_guard = CursorGuard::hide();
+
+    let mut filter = String::new();
+    let mut view = build_view(sections, &filter);
+    if view.selectable.is_empty() {
+        return Ok(None);
+    }
+
+    let mut cursor: usize = current
+        .and_then(|c| selectable_position(&view, c))
         .unwrap_or(0);
 
-    let selection = FuzzySelect::new()
-        .with_prompt("Switch to")
-        .items(&display)
-        .default(default)
-        .interact_opt()
-        .map_err(std::io::Error::from)?;
+    let mut drawn = render(&term, &view, cursor, &filter);
 
-    Ok(selection.map(|i| branches[i].checkout.clone()))
+    loop {
+        let key = term.read_key()?;
+        let preserved = cursor_pick_name(&view, cursor);
+        let mut filter_changed = false;
+
+        match key {
+            Key::ArrowUp => {
+                if !view.selectable.is_empty() {
+                    cursor = if cursor == 0 {
+                        view.selectable.len() - 1
+                    } else {
+                        cursor - 1
+                    };
+                }
+            }
+            Key::ArrowDown => {
+                if !view.selectable.is_empty() {
+                    cursor = (cursor + 1) % view.selectable.len();
+                }
+            }
+            Key::PageUp => {
+                let page = page_size(&term);
+                cursor = cursor.saturating_sub(page);
+            }
+            Key::PageDown => {
+                let page = page_size(&term);
+                let last = view.selectable.len().saturating_sub(1);
+                cursor = (cursor + page).min(last);
+            }
+            Key::Home => cursor = 0,
+            Key::End => {
+                cursor = view.selectable.len().saturating_sub(1);
+            }
+            Key::Char(c) if !c.is_control() => {
+                filter.push(c);
+                filter_changed = true;
+            }
+            Key::Backspace => {
+                if filter.pop().is_some() {
+                    filter_changed = true;
+                }
+            }
+            Key::Enter => {
+                let name = cursor_pick_name(&view, cursor);
+                let _ = term.clear_last_lines(drawn);
+                return Ok(name);
+            }
+            Key::Escape => {
+                if filter.is_empty() {
+                    let _ = term.clear_last_lines(drawn);
+                    return Ok(None);
+                }
+                filter.clear();
+                filter_changed = true;
+            }
+            _ => continue,
+        }
+
+        if filter_changed {
+            view = build_view(sections, &filter);
+            cursor = preserved
+                .as_deref()
+                .and_then(|n| selectable_position(&view, n))
+                .unwrap_or(0);
+        }
+
+        let _ = term.clear_last_lines(drawn);
+        drawn = render(&term, &view, cursor, &filter);
+    }
+}
+
+fn page_size(term: &Term) -> usize {
+    let h = term.size().0 as usize;
+    h.saturating_sub(2).max(1)
+}
+
+fn render(term: &Term, view: &View, cursor: usize, filter: &str) -> usize {
+    let (rows_term, cols_term) = term.size();
+    let height = rows_term as usize;
+    let width = cols_term as usize;
+
+    let prompt = format!(
+        "{} {} {} {}",
+        style("?").green().bold(),
+        style("Switch to").bold(),
+        style("(type to filter):").dim(),
+        filter,
+    );
+    eprintln!("{prompt}");
+    let mut drawn = visual_rows(&prompt, width);
+
+    if view.selectable.is_empty() {
+        let line = style("  (no matches)").dim().to_string();
+        eprintln!("{line}");
+        drawn += visual_rows(&line, width);
+        return drawn;
+    }
+
+    let viewport_h = height.saturating_sub(drawn).max(3);
+    let total_rows = view.rows.len();
+    let cursor_row = view.selectable.get(cursor).copied().unwrap_or(0);
+
+    let cursor_section = view.rows[cursor_row].section_idx;
+    let cursor_heading_row = view
+        .rows
+        .iter()
+        .position(|r| r.section_idx == cursor_section && matches!(r.kind, RowKind::Heading(_)));
+
+    let mut scroll = if total_rows <= viewport_h || cursor_row + 1 < viewport_h {
+        0
+    } else {
+        cursor_row + 1 - viewport_h
+    };
+
+    let sticky = cursor_heading_row.is_some_and(|h| h < scroll);
+    let content_h = if sticky {
+        viewport_h.saturating_sub(1).max(1)
+    } else {
+        viewport_h
+    };
+
+    if sticky && cursor_row >= scroll + content_h {
+        scroll = cursor_row + 1 - content_h;
+    }
+
+    if sticky
+        && let Some(h) = cursor_heading_row
+        && let RowKind::Heading(text) = &view.rows[h].kind
+    {
+        let line = style(text).bold().dim().to_string();
+        eprintln!("{line}");
+        drawn += visual_rows(&line, width);
+    }
+
+    let end = (scroll + content_h).min(total_rows);
+    for r in scroll..end {
+        let line = format_row(&view.rows[r], r == cursor_row);
+        eprintln!("{line}");
+        drawn += visual_rows(&line, width);
+    }
+
+    drawn
+}
+
+fn format_row(row: &RenderRow, is_cursor: bool) -> String {
+    match &row.kind {
+        RowKind::Heading(text) => style(text).bold().dim().to_string(),
+        RowKind::Item(pick) => {
+            let cursor = if is_cursor { ">" } else { " " };
+            let name_with_mark = if pick.is_current {
+                format!("* {}", pick.name)
+            } else {
+                pick.name.clone()
+            };
+            let suffix = if pick.remote_only {
+                " ☁".to_string()
+            } else if pick.missing {
+                " (missing)".to_string()
+            } else {
+                String::new()
+            };
+            let line = format!("  {cursor} {name_with_mark}{suffix}");
+            if pick.missing {
+                style(line).dim().to_string()
+            } else {
+                line
+            }
+        }
+    }
 }
 
 fn prompt_delete_stale_branches(old_branch: Option<&str>, remote: &str) -> AppResult<()> {

--- a/src/app.rs
+++ b/src/app.rs
@@ -99,7 +99,7 @@ fn switch_and_update(target: &str, old_branch: Option<&str>, remote: &str) -> Ap
     }
 
     match merge_result? {
-        git::FastForwardResult::Diverged(branch) => reconcile_diverged(&branch, remote)?,
+        git::FastForwardResult::Diverged => reconcile_diverged(target, remote)?,
         git::FastForwardResult::Merged(report) => report_update(&report),
     }
 
@@ -121,8 +121,7 @@ fn reconcile_diverged(branch: &str, remote: &str) -> AppResult<()> {
     let remote_ref = format!("{remote}/{branch}");
     eprintln!("Local branch has diverged from {remote_ref}.");
 
-    let term = Term::stderr();
-    if !term.is_term() || !confirm(&format!("Rebase onto {remote_ref}?"), false)? {
+    if !confirm(&format!("Rebase onto {remote_ref}?"), false)? {
         eprintln!("Run `git rebase {remote_ref}` or `git merge {remote_ref}` to reconcile.");
         return Err(Error::Diverged);
     }
@@ -140,6 +139,9 @@ fn reconcile_diverged(branch: &str, remote: &str) -> AppResult<()> {
 
 fn confirm(prompt: &str, default_yes: bool) -> AppResult<bool> {
     let term = Term::stderr();
+    if !term.is_term() {
+        return Ok(default_yes);
+    }
     let hint = if default_yes { "[Y/n]" } else { "[y/N]" };
     eprint!(
         "{} {} {} ",
@@ -165,6 +167,12 @@ enum Availability {
     Local,
     RemoteOnly,
     Missing,
+}
+
+impl Availability {
+    fn is_missing(self) -> bool {
+        matches!(self, Availability::Missing)
+    }
 }
 
 #[derive(Clone)]
@@ -312,7 +320,7 @@ fn build_view(sections: &[Section], filter: &str) -> View {
         });
         for pick in matching {
             let idx = rows.len();
-            let is_selectable = !matches!(pick.availability, Availability::Missing);
+            let is_selectable = !pick.availability.is_missing();
             rows.push(RenderRow {
                 kind: RowKind::Item(pick.clone()),
                 section_idx: sec_idx,
@@ -517,7 +525,7 @@ fn format_row(row: &RenderRow, is_cursor: bool) -> String {
                 Availability::Missing => " (missing)",
             };
             let line = format!("  {cursor} {name_with_mark}{suffix}");
-            if matches!(pick.availability, Availability::Missing) {
+            if pick.availability.is_missing() {
                 style(line).dim().to_string()
             } else {
                 line

--- a/src/app.rs
+++ b/src/app.rs
@@ -98,36 +98,80 @@ fn switch_and_update(target: &str, old_branch: Option<&str>, remote: &str) -> Ap
         }
     }
 
-    report_update(merge_result?, remote)?;
+    match merge_result? {
+        git::FastForwardResult::Diverged(branch) => reconcile_diverged(&branch, remote)?,
+        git::FastForwardResult::Merged(report) => report_update(&report),
+    }
 
     prompt_delete_stale_branches(if already_on_target { None } else { old_branch }, remote)?;
 
     Ok(())
 }
 
-fn report_update(result: git::MergeResult, remote: &str) -> AppResult<()> {
+fn report_update(result: &git::MergeReport) {
     match result {
-        git::MergeResult::UpToDate => println!("Already up to date."),
-        git::MergeResult::Pulled(1) => println!("Pulled 1 commit."),
-        git::MergeResult::Pulled(n) => println!("Pulled {n} commits."),
-        git::MergeResult::NoRemote => println!("No remote tracking branch."),
-        git::MergeResult::Diverged(branch) => {
+        git::MergeReport::UpToDate => println!("Already up to date."),
+        git::MergeReport::Pulled(1) => println!("Pulled 1 commit."),
+        git::MergeReport::Pulled(n) => println!("Pulled {n} commits."),
+        git::MergeReport::NoRemote => println!("No remote tracking branch."),
+    }
+}
+
+fn reconcile_diverged(branch: &str, remote: &str) -> AppResult<()> {
+    let remote_ref = format!("{remote}/{branch}");
+    eprintln!("Local branch has diverged from {remote_ref}.");
+
+    let term = Term::stderr();
+    if !term.is_term() || !confirm(&format!("Rebase onto {remote_ref}?"), false)? {
+        eprintln!("Run `git rebase {remote_ref}` or `git merge {remote_ref}` to reconcile.");
+        return Err(Error::Diverged);
+    }
+
+    match git::rebase(&remote_ref)? {
+        git::RebaseOutcome::Clean => Ok(()),
+        git::RebaseOutcome::Aborted => {
             eprintln!(
-                "Local branch has diverged from {remote}/{branch}.\n\
-                 Run `git rebase {remote}/{branch}` or `git merge {remote}/{branch}` to reconcile."
+                "Rebase aborted due to conflicts. Run `git rebase {remote_ref}` manually to reconcile."
             );
-            return Err(Error::Diverged);
+            Err(Error::Diverged)
         }
     }
-    Ok(())
+}
+
+fn confirm(prompt: &str, default_yes: bool) -> AppResult<bool> {
+    let term = Term::stderr();
+    let hint = if default_yes { "[Y/n]" } else { "[y/N]" };
+    eprint!(
+        "{} {} {} ",
+        style("?").green().bold(),
+        style(prompt).bold(),
+        style(hint).dim(),
+    );
+    let _cursor_guard = CursorGuard::hide();
+    loop {
+        let answer = match term.read_key()? {
+            Key::Char('y' | 'Y') => true,
+            Key::Char('n' | 'N') | Key::Escape => false,
+            Key::Enter => default_yes,
+            _ => continue,
+        };
+        eprintln!("{}", if answer { "y" } else { "n" });
+        return Ok(answer);
+    }
+}
+
+#[derive(Clone, Copy)]
+enum Availability {
+    Local,
+    RemoteOnly,
+    Missing,
 }
 
 #[derive(Clone)]
 struct Pick {
     name: String,
     is_current: bool,
-    remote_only: bool,
-    missing: bool,
+    availability: Availability,
 }
 
 struct Section {
@@ -173,11 +217,17 @@ fn build_sections(current: Option<&str>, remote: &str) -> AppResult<Vec<Section>
         .map(|name| {
             let in_local = local_set.contains(name.as_str());
             let in_remote = remote_set.contains(name.as_str());
+            let availability = if in_local {
+                Availability::Local
+            } else if in_remote {
+                Availability::RemoteOnly
+            } else {
+                Availability::Missing
+            };
             Pick {
                 name: name.clone(),
                 is_current: current == Some(name.as_str()),
-                remote_only: !in_local && in_remote,
-                missing: !in_local && !in_remote,
+                availability,
             }
         })
         .collect();
@@ -188,8 +238,7 @@ fn build_sections(current: Option<&str>, remote: &str) -> AppResult<Vec<Section>
         .map(|b| Pick {
             name: b.clone(),
             is_current: current == Some(b.as_str()),
-            remote_only: false,
-            missing: false,
+            availability: Availability::Local,
         })
         .collect();
 
@@ -199,8 +248,7 @@ fn build_sections(current: Option<&str>, remote: &str) -> AppResult<Vec<Section>
         .map(|b| Pick {
             name: b.clone(),
             is_current: false,
-            remote_only: false,
-            missing: false,
+            availability: Availability::Local,
         })
         .collect();
 
@@ -226,16 +274,15 @@ fn build_sections(current: Option<&str>, remote: &str) -> AppResult<Vec<Section>
     Ok(sections)
 }
 
-/// Case-insensitive subsequence match. Empty needle matches everything.
-fn fuzzy_match(needle: &str, haystack: &str) -> bool {
-    if needle.is_empty() {
+/// Subsequence match against a pre-lowered needle. Lowering happens at the
+/// call site so the needle is normalized once per filter, not once per item.
+fn fuzzy_match(needle_lower: &str, haystack: &str) -> bool {
+    if needle_lower.is_empty() {
         return true;
     }
-    let needle: String = needle.chars().flat_map(char::to_lowercase).collect();
-    let haystack: String = haystack.chars().flat_map(char::to_lowercase).collect();
-    let mut iter = haystack.chars();
-    'next: for nc in needle.chars() {
-        for hc in iter.by_ref() {
+    let mut hi = haystack.chars().flat_map(char::to_lowercase);
+    'next: for nc in needle_lower.chars() {
+        for hc in hi.by_ref() {
             if hc == nc {
                 continue 'next;
             }
@@ -246,6 +293,7 @@ fn fuzzy_match(needle: &str, haystack: &str) -> bool {
 }
 
 fn build_view(sections: &[Section], filter: &str) -> View {
+    let needle: String = filter.chars().flat_map(char::to_lowercase).collect();
     let mut rows: Vec<RenderRow> = Vec::new();
     let mut selectable: Vec<usize> = Vec::new();
 
@@ -253,7 +301,7 @@ fn build_view(sections: &[Section], filter: &str) -> View {
         let matching: Vec<&Pick> = sec
             .items
             .iter()
-            .filter(|p| fuzzy_match(filter, &p.name))
+            .filter(|p| fuzzy_match(&needle, &p.name))
             .collect();
         if matching.is_empty() {
             continue;
@@ -264,7 +312,7 @@ fn build_view(sections: &[Section], filter: &str) -> View {
         });
         for pick in matching {
             let idx = rows.len();
-            let is_selectable = !pick.missing;
+            let is_selectable = !matches!(pick.availability, Availability::Missing);
             rows.push(RenderRow {
                 kind: RowKind::Item(pick.clone()),
                 section_idx: sec_idx,
@@ -463,15 +511,13 @@ fn format_row(row: &RenderRow, is_cursor: bool) -> String {
             } else {
                 pick.name.clone()
             };
-            let suffix = if pick.remote_only {
-                " ☁".to_string()
-            } else if pick.missing {
-                " (missing)".to_string()
-            } else {
-                String::new()
+            let suffix = match pick.availability {
+                Availability::Local => "",
+                Availability::RemoteOnly => " ☁",
+                Availability::Missing => " (missing)",
             };
             let line = format!("  {cursor} {name_with_mark}{suffix}");
-            if pick.missing {
+            if matches!(pick.availability, Availability::Missing) {
                 style(line).dim().to_string()
             } else {
                 line

--- a/src/git.rs
+++ b/src/git.rs
@@ -3,11 +3,15 @@ use std::process::Command;
 
 use crate::{AppResult, Error};
 
-pub enum MergeResult {
+pub enum MergeReport {
     UpToDate,
     Pulled(u32),
-    Diverged(String),
     NoRemote,
+}
+
+pub enum FastForwardResult {
+    Merged(MergeReport),
+    Diverged(String),
 }
 
 pub enum StashPopOutcome {
@@ -18,6 +22,11 @@ pub enum StashPopOutcome {
 pub enum FetchOutcome {
     Ok,
     Failed(String),
+}
+
+pub enum RebaseOutcome {
+    Clean,
+    Aborted,
 }
 
 pub fn current_branch() -> AppResult<Option<String>> {
@@ -147,7 +156,26 @@ pub fn fetch(remote: &str) -> AppResult<FetchOutcome> {
     Ok(FetchOutcome::Failed(stderr))
 }
 
-pub fn fast_forward_merge(branch: &str, remote: &str) -> AppResult<MergeResult> {
+/// Rebase the current branch onto `onto` (e.g. `origin/main`). Git's stdout
+/// and stderr stream directly to the terminal so users see progress and
+/// conflict markers in real time. On failure the rebase is aborted, leaving
+/// the working tree clean.
+pub fn rebase(onto: &str) -> AppResult<RebaseOutcome> {
+    let status = Command::new("git")
+        .args(["-c", "advice.skippedCherryPicks=false", "rebase", onto])
+        .status()?;
+    if status.success() {
+        return Ok(RebaseOutcome::Clean);
+    }
+    let _ = Command::new("git")
+        .args(["rebase", "--abort"])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status();
+    Ok(RebaseOutcome::Aborted)
+}
+
+pub fn fast_forward_merge(branch: &str, remote: &str) -> AppResult<FastForwardResult> {
     let remote_ref = format!("{remote}/{branch}");
 
     let has_remote = Command::new("git")
@@ -158,28 +186,37 @@ pub fn fast_forward_merge(branch: &str, remote: &str) -> AppResult<MergeResult> 
         .success();
 
     if !has_remote {
-        return Ok(MergeResult::NoRemote);
+        return Ok(FastForwardResult::Merged(MergeReport::NoRemote));
     }
 
     let before = rev_parse("HEAD")?;
 
-    let status = Command::new("git")
-        .args(["merge", "--ff-only", &remote_ref, "--quiet"])
-        .status()?;
+    // Capture stderr so git's diverging hint and "fatal: Not possible to
+    // fast-forward" don't leak — we surface a tailored message instead.
+    let output = Command::new("git")
+        .args([
+            "-c",
+            "advice.diverging=false",
+            "merge",
+            "--ff-only",
+            &remote_ref,
+            "--quiet",
+        ])
+        .output()?;
 
-    if !status.success() {
-        return Ok(MergeResult::Diverged(branch.to_string()));
+    if !output.status.success() {
+        return Ok(FastForwardResult::Diverged(branch.to_string()));
     }
 
     let after = rev_parse("HEAD")?;
 
     if before == after {
-        return Ok(MergeResult::UpToDate);
+        return Ok(FastForwardResult::Merged(MergeReport::UpToDate));
     }
 
     let output = run(&["rev-list", "--count", &format!("{before}..{after}")])?;
     let count: u32 = output.trim().parse()?;
-    Ok(MergeResult::Pulled(count))
+    Ok(FastForwardResult::Merged(MergeReport::Pulled(count)))
 }
 
 pub fn stale_branches(remote: &str) -> AppResult<Vec<String>> {

--- a/src/git.rs
+++ b/src/git.rs
@@ -11,7 +11,7 @@ pub enum MergeReport {
 
 pub enum FastForwardResult {
     Merged(MergeReport),
-    Diverged(String),
+    Diverged,
 }
 
 pub enum StashPopOutcome {
@@ -205,7 +205,7 @@ pub fn fast_forward_merge(branch: &str, remote: &str) -> AppResult<FastForwardRe
         .output()?;
 
     if !output.status.success() {
-        return Ok(FastForwardResult::Diverged(branch.to_string()));
+        return Ok(FastForwardResult::Diverged);
     }
 
     let after = rev_parse("HEAD")?;

--- a/src/git.rs
+++ b/src/git.rs
@@ -237,6 +237,27 @@ pub fn stale_branches(remote: &str) -> AppResult<Vec<String>> {
     Ok(branches)
 }
 
+/// Branches treated as "pinned" by the picker: the remote's default branch
+/// first, then `git-switch.keep` entries in config order, deduplicated.
+#[must_use]
+pub fn pinned_branches(remote: &str) -> Vec<String> {
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut out: Vec<String> = Vec::new();
+    if let Some(default) = default_branch(remote) {
+        seen.insert(default.clone());
+        out.push(default);
+    }
+    if let Ok(output) = run(&["config", "--get-all", "git-switch.keep"]) {
+        for line in output.lines() {
+            let name = line.trim();
+            if !name.is_empty() && seen.insert(name.to_string()) {
+                out.push(name.to_string());
+            }
+        }
+    }
+    out
+}
+
 fn default_branch(remote: &str) -> Option<String> {
     let head_ref = format!("refs/remotes/{remote}/HEAD");
     let prefix = format!("refs/remotes/{remote}/");

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -489,6 +489,57 @@ fn current_remote_handles_multiline_config_value() {
 }
 
 #[test]
+fn pinned_branches_includes_default_first() {
+    let (_bare, work) = setup();
+
+    git(work.path(), &["remote", "set-head", "origin", "main"]);
+
+    let _cwd = cwd_at(work.path());
+    let pinned = git_switch::git::pinned_branches("origin");
+
+    assert_eq!(
+        pinned.first().map(String::as_str),
+        Some("main"),
+        "expected main first, got: {pinned:?}"
+    );
+}
+
+#[test]
+fn pinned_branches_appends_keep_config_in_order_and_dedups() {
+    let (_bare, work) = setup();
+
+    git(work.path(), &["remote", "set-head", "origin", "main"]);
+    // Repo-local keep entries: deliberately duplicate "main" (the default)
+    // and reorder release branches to verify config order is preserved.
+    git(
+        work.path(),
+        &["config", "--add", "git-switch.keep", "release/v2"],
+    );
+    git(work.path(), &["config", "--add", "git-switch.keep", "main"]);
+    git(
+        work.path(),
+        &["config", "--add", "git-switch.keep", "release/v1"],
+    );
+
+    let _cwd = cwd_at(work.path());
+    let pinned = git_switch::git::pinned_branches("origin");
+
+    let position = |name: &str| pinned.iter().position(|p| p == name);
+    let main = position("main").expect("main should be present");
+    let v2 = position("release/v2").expect("release/v2 should be present");
+    let v1 = position("release/v1").expect("release/v1 should be present");
+
+    assert_eq!(main, 0, "default branch must be first, got: {pinned:?}");
+    assert!(v2 > main, "release/v2 after main, got: {pinned:?}");
+    assert!(v1 > v2, "release/v1 after release/v2, got: {pinned:?}");
+    assert_eq!(
+        pinned.iter().filter(|p| *p == "main").count(),
+        1,
+        "main should be deduped, got: {pinned:?}"
+    );
+}
+
+#[test]
 fn detached_head_can_switch_to_branch() {
     let (_bare, work) = setup();
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -489,6 +489,92 @@ fn current_remote_handles_multiline_config_value() {
 }
 
 #[test]
+fn rebase_replays_local_commits_onto_remote() {
+    let (bare, work) = setup();
+
+    git(work.path(), &["checkout", "-b", "feature"]);
+    fs::write(work.path().join("feature.txt"), "base\n").unwrap();
+    git(work.path(), &["add", "feature.txt"]);
+    git(work.path(), &["commit", "-m", "feature base"]);
+    git(work.path(), &["push", "-u", "origin", "feature"]);
+
+    // Local-only commit on a unique file (no conflict).
+    fs::write(work.path().join("local.txt"), "local\n").unwrap();
+    git(work.path(), &["add", "local.txt"]);
+    git(work.path(), &["commit", "-m", "local commit"]);
+
+    // From a second clone, push a different commit on a different file.
+    let second = clone_bare(bare.path());
+    git(second.path(), &["checkout", "feature"]);
+    fs::write(second.path().join("remote.txt"), "remote\n").unwrap();
+    git(second.path(), &["add", "remote.txt"]);
+    git(second.path(), &["commit", "-m", "remote commit"]);
+    git(second.path(), &["push", "origin", "feature"]);
+
+    git(work.path(), &["fetch", "origin"]);
+
+    let _cwd = cwd_at(work.path());
+    let outcome = git_switch::git::rebase("origin/feature").expect("rebase call failed");
+
+    assert!(
+        matches!(outcome, git_switch::git::RebaseOutcome::Clean),
+        "expected Clean rebase outcome"
+    );
+    assert!(
+        work.path().join("local.txt").exists(),
+        "local.txt should survive the rebase"
+    );
+    assert!(
+        work.path().join("remote.txt").exists(),
+        "remote.txt should be present after rebase"
+    );
+}
+
+#[test]
+fn rebase_aborts_on_conflict_and_leaves_clean_tree() {
+    let (bare, work) = setup();
+
+    git(work.path(), &["checkout", "-b", "feature"]);
+    fs::write(work.path().join("file.txt"), "base\n").unwrap();
+    git(work.path(), &["add", "file.txt"]);
+    git(work.path(), &["commit", "-m", "feature base"]);
+    git(work.path(), &["push", "-u", "origin", "feature"]);
+
+    // Conflicting local change.
+    fs::write(work.path().join("file.txt"), "local\n").unwrap();
+    git(work.path(), &["add", "file.txt"]);
+    git(work.path(), &["commit", "-m", "local"]);
+
+    // Conflicting remote change (force-pushed from a second clone).
+    let second = clone_bare(bare.path());
+    git(second.path(), &["checkout", "feature"]);
+    fs::write(second.path().join("file.txt"), "remote\n").unwrap();
+    git(second.path(), &["add", "file.txt"]);
+    git(second.path(), &["commit", "-m", "remote"]);
+    git(second.path(), &["push", "--force", "origin", "feature"]);
+
+    git(work.path(), &["fetch", "origin"]);
+
+    let _cwd = cwd_at(work.path());
+    let outcome = git_switch::git::rebase("origin/feature").expect("rebase call failed");
+
+    assert!(
+        matches!(outcome, git_switch::git::RebaseOutcome::Aborted),
+        "expected Aborted rebase outcome"
+    );
+
+    let git_dir = work.path().join(".git");
+    assert!(
+        !git_dir.join("rebase-merge").exists(),
+        "rebase-merge directory should not exist after abort"
+    );
+    assert!(
+        !git_dir.join("rebase-apply").exists(),
+        "rebase-apply directory should not exist after abort"
+    );
+}
+
+#[test]
 fn pinned_branches_includes_default_first() {
     let (_bare, work) = setup();
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -76,6 +76,12 @@ fn setup_with_remote(remote: &str) -> (TempDir, TempDir) {
     git(bare.path(), &["init", "--bare"]);
 
     git(work.path(), &["init", "-b", "main"]);
+    // Library code under test spawns its own `git` subprocesses without our
+    // helper's GIT_*_NAME/EMAIL env, so commits it makes (e.g. during rebase)
+    // need identity from .git/config — otherwise CI hosts without a global
+    // gitconfig fail with "empty ident name".
+    git(work.path(), &["config", "user.name", "test"]);
+    git(work.path(), &["config", "user.email", "test@example.com"]);
     git(
         work.path(),
         &["remote", "add", remote, bare.path().to_str().unwrap()],


### PR DESCRIPTION
## Summary

- Group branches in the picker under **Pinned**, **Local**, and **Remote** headings, with a sticky heading and per-section availability indicators (`☁`, `(missing)`).
- When fast-forward fails because local commits diverged from the remote, prompt to rebase onto the remote-tracking branch instead of just printing guidance. Aborts cleanly on conflict so the working tree returns to its prior state.
- Replace `Pick`'s boolean `remote_only` / `missing` flags with an `Availability` enum, and split `MergeResult` into `MergeReport` + `FastForwardResult` to model the two distinct outcomes.
- Pre-lower the fuzzy-match needle once per filter pass instead of once per item.
- New tests cover pinned-branch ordering/dedup and the rebase clean/aborted outcomes.

## Test plan

- [x] `just test` — 20 tests pass
- [x] Manual: switch to a branch that fast-forwards cleanly
- [x] Manual: switch to a branch where local has diverged from remote and confirm the rebase prompt
- [x] Manual: decline the rebase prompt and confirm the guidance message
- [x] Manual: trigger a rebase conflict and confirm the working tree is restored
- [x] Manual: run picker with `git-switch.keep` config to verify Pinned section ordering