### PR TITLE
feat: add worktree support (git-switch wt)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A fast, interactive Git branch switcher. Pick a branch, fetch & fast-forward it,
 - **Auto-stash** — dirty working tree? Changes are stashed before switching and restored after
 - **Fast-forward pull** — fetches from origin and fast-forward merges, warns if the branch has diverged
 - **Merged branch cleanup** — prompts to delete local branches that have been merged into the current branch
+- **Worktree support** — create, switch into, list, and remove worktrees with `git-switch wt`
 
 ## Install
 
@@ -30,6 +31,41 @@ git-switch
 # Direct — switch to a specific branch
 git-switch main
 ```
+
+## Worktrees
+
+```sh
+# Interactive picker: existing worktrees + branches without one; "Create new: <typed>" when filter matches nothing
+git-switch wt
+
+# DWIM — switch into the worktree for `feature`, or create one if it doesn't exist.
+# If `feature` doesn't exist as a branch, a new one is created from the remote's default branch.
+git-switch wt feature
+
+# List all worktrees
+git-switch wt ls
+
+# Remove one or more worktrees (also deletes the branch when it's fully merged;
+# a branch with unmerged commits is kept and reported)
+git-switch wt rm           # multi-select picker
+git-switch wt rm feature   # specific
+```
+
+Worktrees land at `../worktrees/<repo>/<branch>` relative to the main checkout. Branch names with slashes (`feature/foo`) preserve their structure as subdirectories.
+
+Plain `git-switch <branch>` also knows about worktrees: if the picked branch is already checked out in another worktree, it hands off to that worktree rather than failing with git's "already checked out" error.
+
+### Shell integration (required for `cd`)
+
+A child process can't change its parent shell's directory. Worktree commands print their target path on stdout; a small shell function reads that and runs `cd` for you.
+
+```sh
+just install-shell-integration
+# Then add the printed line to your shell rc (e.g. ~/.zshrc):
+#   source ~/.config/git-switch/git-switch.sh
+```
+
+Without the wrapper, `git-switch wt foo` still creates / finds the worktree and prints its path — you'd just `cd` there manually.
 
 ## Shell Completions
 

--- a/completions/_git-switch
+++ b/completions/_git-switch
@@ -1,9 +1,32 @@
 #compdef git-switch
 
 _git-switch() {
+  local -a subcommands worktree_subs
+  subcommands=(
+    'wt:Worktree commands'
+    'worktree:Worktree commands'
+  )
+  worktree_subs=(
+    'ls:List worktrees'
+    'list:List worktrees'
+    'rm:Remove worktree (also deletes branch)'
+    'remove:Remove worktree (also deletes branch)'
+  )
+
   local branches
   branches=(${(f)"$(git branch --format='%(refname:short)' 2>/dev/null)"})
-  _describe 'branch' branches
+
+  if (( CURRENT == 2 )); then
+    _describe -t subcommands 'subcommand' subcommands
+    _describe -t branches 'branch' branches
+  elif (( CURRENT == 3 )) && [[ "$words[2]" == (wt|worktree) ]]; then
+    _describe -t subcommands 'worktree subcommand' worktree_subs
+    _describe -t branches 'branch' branches
+  elif (( CURRENT == 4 )) && [[ "$words[2]" == (wt|worktree) && "$words[3]" == (rm|remove) ]]; then
+    _describe -t branches 'branch' branches
+  else
+    _describe -t branches 'branch' branches
+  fi
 }
 
 _git-switch "$@"

--- a/completions/git-switch.bash
+++ b/completions/git-switch.bash
@@ -1,7 +1,27 @@
 _git_switch_completions() {
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  local prev="${COMP_WORDS[COMP_CWORD-1]}"
+  local sub="${COMP_WORDS[1]}"
   local branches
   branches=$(git branch --format='%(refname:short)' 2>/dev/null)
-  COMPREPLY=($(compgen -W "$branches" -- "${COMP_WORDS[COMP_CWORD]}"))
+
+  case "$COMP_CWORD" in
+    1)
+      COMPREPLY=($(compgen -W "wt worktree $branches" -- "$cur"))
+      ;;
+    2)
+      if [[ "$sub" == "wt" || "$sub" == "worktree" ]]; then
+        COMPREPLY=($(compgen -W "ls list rm remove $branches" -- "$cur"))
+      else
+        COMPREPLY=($(compgen -W "$branches" -- "$cur"))
+      fi
+      ;;
+    3)
+      if [[ "$sub" == "wt" || "$sub" == "worktree" ]] && [[ "$prev" == "rm" || "$prev" == "remove" ]]; then
+        COMPREPLY=($(compgen -W "$branches" -- "$cur"))
+      fi
+      ;;
+  esac
 }
 
 complete -F _git_switch_completions git-switch

--- a/completions/git-switch.fish
+++ b/completions/git-switch.fish
@@ -1,1 +1,14 @@
-complete -c git-switch -f -a '(git branch --format="%(refname:short)" 2>/dev/null)'
+function __git_switch_branches
+    git branch --format="%(refname:short)" 2>/dev/null
+end
+
+# Top-level: branches + subcommands.
+complete -c git-switch -f -n '__fish_is_nth_token 1' -a '(__git_switch_branches)'
+complete -c git-switch -f -n '__fish_is_nth_token 1' -a 'wt worktree' -d 'Worktree commands'
+
+# After `wt`/`worktree`: subverbs + branches.
+complete -c git-switch -f -n '__fish_seen_subcommand_from wt worktree; and __fish_is_nth_token 2' -a 'ls list rm remove'
+complete -c git-switch -f -n '__fish_seen_subcommand_from wt worktree; and __fish_is_nth_token 2' -a '(__git_switch_branches)'
+
+# After `wt rm`: branches.
+complete -c git-switch -f -n '__fish_seen_subcommand_from wt worktree; and __fish_seen_subcommand_from rm remove' -a '(__git_switch_branches)'

--- a/justfile
+++ b/justfile
@@ -36,6 +36,25 @@ install-completions:
       echo "Unsupported shell: $SHELL" && exit 1 ;; \
   esac
 
+# Install the shell wrapper function (required for worktree cd hand-off).
+install-shell-integration:
+  #!/usr/bin/env sh
+  mkdir -p ~/.config/git-switch
+  case "$(basename "$SHELL")" in \
+    zsh|bash) \
+      cp shell/git-switch.sh ~/.config/git-switch/git-switch.sh && \
+      echo "Installed shell integration to ~/.config/git-switch/git-switch.sh" && \
+      echo "Add to your shell rc:" && \
+      echo "  source ~/.config/git-switch/git-switch.sh" ;; \
+    fish) \
+      cp shell/git-switch.fish ~/.config/git-switch/git-switch.fish && \
+      echo "Installed shell integration to ~/.config/git-switch/git-switch.fish" && \
+      echo "Add to ~/.config/fish/conf.d/git-switch.fish:" && \
+      echo "  source ~/.config/git-switch/git-switch.fish" ;; \
+    *) \
+      echo "Unsupported shell: $SHELL" && exit 1 ;; \
+  esac
+
 # Build a release binary.
 build-release:
   cargo build --release

--- a/shell/git-switch.fish
+++ b/shell/git-switch.fish
@@ -1,0 +1,26 @@
+# git-switch shell integration (fish)
+#
+# Source from ~/.config/fish/conf.d/:
+#   source ~/.config/git-switch/git-switch.fish
+#
+# Behaviour mirrors the bash/zsh wrapper: the binary prints the target path on
+# stdout only when a cd hand-off is wanted; everything else is on stderr.
+
+function git-switch
+    set -l out (command git-switch $argv)
+    set -l rc $status
+    if test -z "$out"
+        return $rc
+    end
+    if test (count $out) -gt 1
+        printf '%s\n' $out
+        return $rc
+    end
+    if test -d "$out"
+        cd -- "$out"
+        or return $status
+    else
+        printf '%s\n' "$out"
+    end
+    return $rc
+end

--- a/shell/git-switch.sh
+++ b/shell/git-switch.sh
@@ -1,0 +1,36 @@
+# git-switch shell integration (bash/zsh)
+#
+# Wraps the `git-switch` binary so that worktree create / switch operations
+# `cd` the parent shell into the target directory. The binary prints the
+# target path on stdout only when a `cd` hand-off is wanted; everything else
+# (prompts, status, errors) is written to stderr.
+#
+# Source from your shell rc:
+#   source ~/.config/git-switch/git-switch.sh
+#
+# Behaviour:
+#   - empty stdout              → nothing to do
+#   - single-line existing dir  → cd there
+#   - anything else             → print stdout through unchanged
+
+git-switch() {
+  local out
+  out="$(command git-switch "$@")"
+  local rc=$?
+  if [ -z "$out" ]; then
+    return $rc
+  fi
+  case "$out" in
+    *$'\n'*)
+      printf '%s\n' "$out"
+      ;;
+    *)
+      if [ -d "$out" ]; then
+        cd -- "$out" || return $?
+      else
+        printf '%s\n' "$out"
+      fi
+      ;;
+  esac
+  return $rc
+}

--- a/src/app.rs
+++ b/src/app.rs
@@ -5,10 +5,12 @@ use indicatif::ProgressBar;
 
 use crate::{AppResult, Error, git};
 
-struct CursorGuard(Term);
+pub mod wt;
+
+pub(crate) struct CursorGuard(Term);
 
 impl CursorGuard {
-    fn hide() -> Self {
+    pub(crate) fn hide() -> Self {
         let term = Term::stderr();
         let _ = term.hide_cursor();
         Self(term)
@@ -32,6 +34,36 @@ pub fn run(target: Option<&str>) -> AppResult<()> {
             None => return Ok(()),
         },
     };
+
+    // `git checkout` refuses for a branch already checked out in another
+    // worktree; hand off to the shell wrapper instead.
+    if old_branch.as_deref() != Some(target.as_str())
+        && let Some(held_by) = git::worktree_for_branch(&git::worktree_list()?, &target)
+    {
+        // The target may track a different remote than the current branch.
+        let target_remote = git::current_remote(Some(target.as_str()));
+        if let Err(e) = wt::update_in(&held_by.path, &target, &target_remote) {
+            eprintln!(
+                "{} update of {} failed: {e}",
+                style("!").yellow().bold(),
+                target,
+            );
+        }
+        eprintln!(
+            "{} {} is checked out at {}",
+            style("→").cyan().bold(),
+            target,
+            held_by.path.display()
+        );
+        if let Err(e) = prompt_delete_stale_branches(None, &remote) {
+            eprintln!(
+                "{} stale-branch check failed: {e}",
+                style("!").yellow().bold()
+            );
+        }
+        handoff_cd(&held_by.path);
+        return Ok(());
+    }
 
     let stashed = if git::has_tracked_changes()? {
         git::stash_push()?;
@@ -75,14 +107,33 @@ fn switch_and_update(target: &str, old_branch: Option<&str>, remote: &str) -> Ap
         git::checkout(target)?;
     }
 
+    match fetch_and_ff(None, target, remote)? {
+        git::FastForwardResult::Diverged => reconcile_diverged(target, remote)?,
+        git::FastForwardResult::Merged(report) => report_update(&report),
+    }
+
+    prompt_delete_stale_branches(if already_on_target { None } else { old_branch }, remote)?;
+
+    Ok(())
+}
+
+/// Fetch `remote` then fast-forward `branch` onto it, optionally inside the
+/// worktree at `dir` (via `git -C`). Shows a spinner and surfaces fetch
+/// failures; the caller decides how to handle the [`git::FastForwardResult`]
+/// (the in-place switch offers a rebase on diverge; worktree updates don't).
+pub(crate) fn fetch_and_ff(
+    dir: Option<&std::path::Path>,
+    branch: &str,
+    remote: &str,
+) -> AppResult<git::FastForwardResult> {
     let (fetch_outcome, merge_result) = {
-        let spinner = ProgressBar::new_spinner().with_message(format!("Updating {target}…"));
+        let spinner = ProgressBar::new_spinner().with_message(format!("Updating {branch}…"));
         let _cursor_guard = CursorGuard::hide();
         spinner.enable_steady_tick(std::time::Duration::from_millis(80));
 
         let fetch_outcome =
-            git::fetch(remote).unwrap_or_else(|e| git::FetchOutcome::Failed(e.to_string()));
-        let result = git::fast_forward_merge(target, remote);
+            git::fetch(dir, remote).unwrap_or_else(|e| git::FetchOutcome::Failed(e.to_string()));
+        let result = git::fast_forward_merge(dir, branch, remote);
 
         spinner.finish_and_clear();
         (fetch_outcome, result)
@@ -98,22 +149,15 @@ fn switch_and_update(target: &str, old_branch: Option<&str>, remote: &str) -> Ap
         }
     }
 
-    match merge_result? {
-        git::FastForwardResult::Diverged => reconcile_diverged(target, remote)?,
-        git::FastForwardResult::Merged(report) => report_update(&report),
-    }
-
-    prompt_delete_stale_branches(if already_on_target { None } else { old_branch }, remote)?;
-
-    Ok(())
+    merge_result
 }
 
-fn report_update(result: &git::MergeReport) {
+pub(crate) fn report_update(result: &git::MergeReport) {
     match result {
-        git::MergeReport::UpToDate => println!("Already up to date."),
-        git::MergeReport::Pulled(1) => println!("Pulled 1 commit."),
-        git::MergeReport::Pulled(n) => println!("Pulled {n} commits."),
-        git::MergeReport::NoRemote => println!("No remote tracking branch."),
+        git::MergeReport::UpToDate => eprintln!("Already up to date."),
+        git::MergeReport::Pulled(1) => eprintln!("Pulled 1 commit."),
+        git::MergeReport::Pulled(n) => eprintln!("Pulled {n} commits."),
+        git::MergeReport::NoRemote => eprintln!("No remote tracking branch."),
     }
 }
 
@@ -137,7 +181,7 @@ fn reconcile_diverged(branch: &str, remote: &str) -> AppResult<()> {
     }
 }
 
-fn confirm(prompt: &str, default_yes: bool) -> AppResult<bool> {
+pub(crate) fn confirm(prompt: &str, default_yes: bool) -> AppResult<bool> {
     let term = Term::stderr();
     if !term.is_term() {
         return Ok(default_yes);
@@ -163,7 +207,7 @@ fn confirm(prompt: &str, default_yes: bool) -> AppResult<bool> {
 }
 
 #[derive(Clone, Copy)]
-enum Availability {
+pub(crate) enum Availability {
     Local,
     RemoteOnly,
     Missing,
@@ -175,21 +219,29 @@ impl Availability {
     }
 }
 
-#[derive(Clone)]
-struct Pick {
-    name: String,
-    is_current: bool,
-    availability: Availability,
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PickKind {
+    Branch,
+    Worktree,
 }
 
-struct Section {
-    heading: &'static str,
-    items: Vec<Pick>,
+#[derive(Clone)]
+pub(crate) struct Pick {
+    pub name: String,
+    pub is_current: bool,
+    pub availability: Availability,
+    pub kind: PickKind,
+}
+
+pub(crate) struct Section {
+    pub heading: &'static str,
+    pub items: Vec<Pick>,
 }
 
 enum RowKind {
     Heading(String),
     Item(Pick),
+    CreateNew(String),
 }
 
 struct RenderRow {
@@ -202,12 +254,38 @@ struct View {
     selectable: Vec<usize>,
 }
 
-fn select_branch(current: Option<&str>, remote: &str) -> AppResult<Option<String>> {
-    let sections = build_sections(current, remote)?;
-    pick(current, &sections)
+pub(crate) enum Selection {
+    Existing { name: String, kind: PickKind },
+    Create(String),
 }
 
-fn build_sections(current: Option<&str>, remote: &str) -> AppResult<Vec<Section>> {
+#[derive(Clone, Copy)]
+pub(crate) struct PickerOptions {
+    pub prompt: &'static str,
+    pub allow_create_from_filter: bool,
+}
+
+fn select_branch(current: Option<&str>, remote: &str) -> AppResult<Option<String>> {
+    let sections = build_sections(current, remote, &HashSet::new())?;
+    let selection = pick(
+        current,
+        &sections,
+        PickerOptions {
+            prompt: "Switch to",
+            allow_create_from_filter: false,
+        },
+    )?;
+    Ok(selection.map(|s| match s {
+        Selection::Existing { name, .. } => name,
+        Selection::Create(_) => unreachable!("create-from-filter disabled"),
+    }))
+}
+
+pub(crate) fn build_sections(
+    current: Option<&str>,
+    remote: &str,
+    exclude: &HashSet<String>,
+) -> AppResult<Vec<Section>> {
     let local = git::local_branches()?;
     let remote_only = git::remote_only_branches(&local, remote).unwrap_or_default();
 
@@ -222,6 +300,7 @@ fn build_sections(current: Option<&str>, remote: &str) -> AppResult<Vec<Section>
 
     let pinned_picks: Vec<Pick> = pinned_names
         .iter()
+        .filter(|name| !exclude.contains(name.as_str()))
         .map(|name| {
             let in_local = local_set.contains(name.as_str());
             let in_remote = remote_set.contains(name.as_str());
@@ -236,27 +315,30 @@ fn build_sections(current: Option<&str>, remote: &str) -> AppResult<Vec<Section>
                 name: name.clone(),
                 is_current: current == Some(name.as_str()),
                 availability,
+                kind: PickKind::Branch,
             }
         })
         .collect();
 
     let local_picks: Vec<Pick> = local
         .iter()
-        .filter(|b| !pinned_set.contains(b.as_str()))
+        .filter(|b| !pinned_set.contains(b.as_str()) && !exclude.contains(b.as_str()))
         .map(|b| Pick {
             name: b.clone(),
             is_current: current == Some(b.as_str()),
             availability: Availability::Local,
+            kind: PickKind::Branch,
         })
         .collect();
 
     let remote_picks: Vec<Pick> = remote_only
         .iter()
-        .filter(|b| !pinned_set.contains(b.as_str()))
+        .filter(|b| !pinned_set.contains(b.as_str()) && !exclude.contains(b.as_str()))
         .map(|b| Pick {
             name: b.clone(),
             is_current: false,
             availability: Availability::Local,
+            kind: PickKind::Branch,
         })
         .collect();
 
@@ -300,7 +382,7 @@ fn fuzzy_match(needle_lower: &str, haystack: &str) -> bool {
     true
 }
 
-fn build_view(sections: &[Section], filter: &str) -> View {
+fn build_view(sections: &[Section], filter: &str, opts: PickerOptions) -> View {
     let needle: String = filter.chars().flat_map(char::to_lowercase).collect();
     let mut rows: Vec<RenderRow> = Vec::new();
     let mut selectable: Vec<usize> = Vec::new();
@@ -331,15 +413,27 @@ fn build_view(sections: &[Section], filter: &str) -> View {
         }
     }
 
+    if opts.allow_create_from_filter && selectable.is_empty() && !filter.is_empty() {
+        let idx = rows.len();
+        rows.push(RenderRow {
+            kind: RowKind::CreateNew(filter.to_string()),
+            section_idx: 0,
+        });
+        selectable.push(idx);
+    }
+
     View { rows, selectable }
 }
 
-fn cursor_pick_name(view: &View, cursor: usize) -> Option<String> {
+fn cursor_selection(view: &View, cursor: usize) -> Option<Selection> {
     let &row_idx = view.selectable.get(cursor)?;
-    if let RowKind::Item(p) = &view.rows[row_idx].kind {
-        Some(p.name.clone())
-    } else {
-        None
+    match &view.rows[row_idx].kind {
+        RowKind::Item(p) => Some(Selection::Existing {
+            name: p.name.clone(),
+            kind: p.kind,
+        }),
+        RowKind::CreateNew(name) => Some(Selection::Create(name.clone())),
+        RowKind::Heading(_) => None,
     }
 }
 
@@ -349,13 +443,17 @@ fn selectable_position(view: &View, name: &str) -> Option<usize> {
         .position(|&i| matches!(&view.rows[i].kind, RowKind::Item(p) if p.name == name))
 }
 
-fn pick(current: Option<&str>, sections: &[Section]) -> AppResult<Option<String>> {
+pub(crate) fn pick(
+    current: Option<&str>,
+    sections: &[Section],
+    opts: PickerOptions,
+) -> AppResult<Option<Selection>> {
     let term = Term::stderr();
     let _cursor_guard = CursorGuard::hide();
 
     let mut filter = String::new();
-    let mut view = build_view(sections, &filter);
-    if view.selectable.is_empty() {
+    let mut view = build_view(sections, &filter, opts);
+    if view.selectable.is_empty() && !opts.allow_create_from_filter {
         return Ok(None);
     }
 
@@ -363,11 +461,14 @@ fn pick(current: Option<&str>, sections: &[Section]) -> AppResult<Option<String>
         .and_then(|c| selectable_position(&view, c))
         .unwrap_or(0);
 
-    let mut drawn = render(&term, &view, cursor, &filter);
+    let mut drawn = render(&term, &view, cursor, &filter, opts.prompt);
 
     loop {
         let key = term.read_key()?;
-        let preserved = cursor_pick_name(&view, cursor);
+        let preserved = match cursor_selection(&view, cursor) {
+            Some(Selection::Existing { name, .. }) => Some(name),
+            _ => None,
+        };
         let mut filter_changed = false;
 
         match key {
@@ -408,9 +509,9 @@ fn pick(current: Option<&str>, sections: &[Section]) -> AppResult<Option<String>
                 }
             }
             Key::Enter => {
-                let name = cursor_pick_name(&view, cursor);
+                let selection = cursor_selection(&view, cursor);
                 let _ = term.clear_last_lines(drawn);
-                return Ok(name);
+                return Ok(selection);
             }
             Key::Escape => {
                 if filter.is_empty() {
@@ -424,7 +525,7 @@ fn pick(current: Option<&str>, sections: &[Section]) -> AppResult<Option<String>
         }
 
         if filter_changed {
-            view = build_view(sections, &filter);
+            view = build_view(sections, &filter, opts);
             cursor = preserved
                 .as_deref()
                 .and_then(|n| selectable_position(&view, n))
@@ -432,7 +533,7 @@ fn pick(current: Option<&str>, sections: &[Section]) -> AppResult<Option<String>
         }
 
         let _ = term.clear_last_lines(drawn);
-        drawn = render(&term, &view, cursor, &filter);
+        drawn = render(&term, &view, cursor, &filter, opts.prompt);
     }
 }
 
@@ -441,7 +542,7 @@ fn page_size(term: &Term) -> usize {
     h.saturating_sub(2).max(1)
 }
 
-fn render(term: &Term, view: &View, cursor: usize, filter: &str) -> usize {
+fn render(term: &Term, view: &View, cursor: usize, filter: &str, prompt_label: &str) -> usize {
     let (rows_term, cols_term) = term.size();
     let height = rows_term as usize;
     let width = cols_term as usize;
@@ -449,7 +550,7 @@ fn render(term: &Term, view: &View, cursor: usize, filter: &str) -> usize {
     let prompt = format!(
         "{} {} {} {}",
         style("?").green().bold(),
-        style("Switch to").bold(),
+        style(prompt_label).bold(),
         style("(type to filter):").dim(),
         filter,
     );
@@ -531,10 +632,21 @@ fn format_row(row: &RenderRow, is_cursor: bool) -> String {
                 line
             }
         }
+        RowKind::CreateNew(name) => {
+            let cursor = if is_cursor { ">" } else { " " };
+            format!(
+                "  {cursor} {} {}",
+                style("+").green().bold(),
+                style(format!("Create new: {name}")).italic()
+            )
+        }
     }
 }
 
-fn prompt_delete_stale_branches(old_branch: Option<&str>, remote: &str) -> AppResult<()> {
+pub(crate) fn prompt_delete_stale_branches(
+    old_branch: Option<&str>,
+    remote: &str,
+) -> AppResult<()> {
     let all_stale = git::stale_branches(remote)?;
     if all_stale.is_empty() {
         return Ok(());
@@ -575,6 +687,24 @@ fn prompt_delete_stale_branches(old_branch: Option<&str>, remote: &str) -> AppRe
     Ok(())
 }
 
+/// Hand a target directory to the shell wrapper, which reads it from stdout and
+/// runs `cd`. When stdout is a terminal the wrapper isn't capturing it, so a
+/// bare path would just be dumped to the screen with no `cd` — print an
+/// actionable hint to stderr instead.
+pub(crate) fn handoff_cd(path: &std::path::Path) {
+    use std::io::IsTerminal;
+    if std::io::stdout().is_terminal() {
+        eprintln!(
+            "{} shell integration not active — can't cd for you. Run:",
+            style("!").yellow().bold(),
+        );
+        eprintln!("  cd {}", path.display());
+        eprintln!("  (enable auto-cd: see README \"Shell integration\")");
+    } else {
+        println!("{}", path.display());
+    }
+}
+
 fn visual_rows(text: &str, width: usize) -> usize {
     if width == 0 {
         return 1;
@@ -583,7 +713,11 @@ fn visual_rows(text: &str, width: usize) -> usize {
     if w == 0 { 1 } else { w.div_ceil(width) }
 }
 
-fn multi_select(prompt: &str, items: &[String], defaults: &[bool]) -> AppResult<Vec<usize>> {
+pub(crate) fn multi_select(
+    prompt: &str,
+    items: &[String],
+    defaults: &[bool],
+) -> AppResult<Vec<usize>> {
     let term = Term::stderr();
     let mut selected = defaults.to_vec();
     let mut cursor = 0usize;

--- a/src/app.rs
+++ b/src/app.rs
@@ -449,6 +449,11 @@ pub(crate) fn pick(
     opts: PickerOptions,
 ) -> AppResult<Option<Selection>> {
     let term = Term::stderr();
+    // Non-interactive (piped/CI): no TTY to drive the picker, so select nothing
+    // instead of blocking on key input.
+    if !term.is_term() {
+        return Ok(None);
+    }
     let _cursor_guard = CursorGuard::hide();
 
     let mut filter = String::new();
@@ -719,6 +724,11 @@ pub(crate) fn multi_select(
     defaults: &[bool],
 ) -> AppResult<Vec<usize>> {
     let term = Term::stderr();
+    // Non-interactive (piped/CI): we can't prompt, so make no selection rather
+    // than blocking on key input or silently acting on the defaults.
+    if !term.is_term() {
+        return Ok(Vec::new());
+    }
     let mut selected = defaults.to_vec();
     let mut cursor = 0usize;
     let header = format!("{} {}", style("?").green().bold(), style(prompt).bold());

--- a/src/app/wt.rs
+++ b/src/app/wt.rs
@@ -1,0 +1,361 @@
+use std::collections::HashSet;
+use std::env;
+use std::path::{Path, PathBuf};
+
+use console::style;
+use indicatif::ProgressBar;
+
+use super::{
+    Availability, CursorGuard, Pick, PickKind, PickerOptions, Section, Selection, build_sections,
+    fetch_and_ff, handoff_cd, multi_select, pick, prompt_delete_stale_branches, report_update,
+};
+use crate::{AppResult, Error, git};
+
+enum Action {
+    CdToExisting(git::Worktree),
+    CreateForBranch(String),
+    CreateNewBranch(String),
+}
+
+pub fn run(target: Option<&str>) -> AppResult<()> {
+    let worktrees = git::worktree_list()?;
+    let main = main_of(&worktrees)?;
+    let current_branch = git::current_branch()?;
+    let remote = git::current_remote(current_branch.as_deref());
+
+    let action = match target {
+        Some(name) => resolve_target(name, &worktrees, &remote)?,
+        None => match select(&worktrees, current_branch.as_deref(), &remote)? {
+            Some(a) => a,
+            None => return Ok(()),
+        },
+    };
+
+    let target_path = match action {
+        Action::CdToExisting(wt) => {
+            let branch = wt.branch.clone().unwrap_or_default();
+            // The worktree's branch may track a different remote than ours.
+            let branch_remote = git::current_remote(Some(branch.as_str()));
+            if let Err(e) = update_in(&wt.path, &branch, &branch_remote) {
+                eprintln!(
+                    "{} update of {} failed: {e}",
+                    style("!").yellow().bold(),
+                    branch,
+                );
+            }
+            eprintln!(
+                "{} switched to worktree at {}",
+                style("→").cyan().bold(),
+                wt.path.display()
+            );
+            wt.path
+        }
+        Action::CreateForBranch(branch) => {
+            let branch_remote = git::current_remote(Some(branch.as_str()));
+            create_worktree(&main.path, &branch, None, &branch_remote)?
+        }
+        Action::CreateNewBranch(branch) => {
+            let default = git::default_branch(&remote).ok_or_else(|| Error::Git {
+                command: "worktree add".into(),
+                message: format!("no default branch on {remote}; cannot pick a base"),
+            })?;
+            let base = format!("{remote}/{default}");
+            create_worktree(&main.path, &branch, Some(&base), &remote)?
+        }
+    };
+
+    if let Err(e) = prompt_delete_stale_branches(None, &remote) {
+        eprintln!(
+            "{} stale-branch check failed: {e}",
+            style("!").yellow().bold()
+        );
+    }
+    handoff_cd(&target_path);
+    Ok(())
+}
+
+pub fn run_ls() -> AppResult<()> {
+    let worktrees = git::worktree_list()?;
+    let max_branch = worktrees
+        .iter()
+        .map(|w| w.branch.as_deref().unwrap_or("(detached)").len())
+        .max()
+        .unwrap_or(0);
+    for w in worktrees {
+        let label = w.branch.as_deref().unwrap_or("(detached)");
+        let main_mark = if w.is_main { "*" } else { " " };
+        println!("{main_mark} {label:max_branch$}  {}", w.path.display());
+    }
+    Ok(())
+}
+
+pub fn run_rm(target: Option<&str>) -> AppResult<()> {
+    let worktrees = git::worktree_list()?;
+    let main = main_of(&worktrees)?.clone();
+    let removable: Vec<git::Worktree> = worktrees
+        .into_iter()
+        .filter(|w| !w.is_main && w.branch.is_some())
+        .collect();
+
+    if removable.is_empty() {
+        eprintln!("No worktrees to remove.");
+        return Ok(());
+    }
+
+    let selected_indices: Vec<usize> = if let Some(name) = target {
+        let i = removable
+            .iter()
+            .position(|w| w.branch.as_deref() == Some(name))
+            .ok_or_else(|| Error::Git {
+                command: "worktree remove".into(),
+                message: format!("no worktree for branch '{name}'"),
+            })?;
+        vec![i]
+    } else {
+        let items: Vec<String> = removable
+            .iter()
+            .map(|w| w.branch.clone().unwrap_or_default())
+            .collect();
+        let defaults = vec![false; items.len()];
+        multi_select(
+            "Remove worktrees (space to toggle, →/← all/none)",
+            &items,
+            &defaults,
+        )?
+    };
+
+    if selected_indices.is_empty() {
+        return Ok(());
+    }
+
+    // Canonicalize both sides: `env::current_dir()` and git's reported path can
+    // disagree on symlinks (e.g. macOS /var vs /private/var), which would let a
+    // plain `starts_with` miss a cwd that really is inside a doomed worktree.
+    let cwd = env::current_dir().ok().and_then(|c| c.canonicalize().ok());
+    let cwd_will_vanish = selected_indices.iter().any(|&i| {
+        let wt_path = removable[i]
+            .path
+            .canonicalize()
+            .unwrap_or_else(|_| removable[i].path.clone());
+        cwd.as_ref().is_some_and(|c| c.starts_with(&wt_path))
+    });
+
+    if cwd_will_vanish {
+        env::set_current_dir(&main.path)?;
+    }
+
+    for &i in &selected_indices {
+        let wt = &removable[i];
+        match git::worktree_remove(&wt.path)? {
+            git::WorktreeRemoveOutcome::Removed => {
+                let branch = wt.branch.as_deref().unwrap_or_default();
+                match git::delete_branch_if_merged(branch)? {
+                    git::BranchDeleteOutcome::Deleted => eprintln!(
+                        "{} removed worktree {branch} (branch deleted)",
+                        style("✓").green().bold(),
+                    ),
+                    git::BranchDeleteOutcome::NotMerged => eprintln!(
+                        "{} removed worktree {branch}; kept branch with unmerged commits \
+                         (run `git branch -D {branch}` to force-delete)",
+                        style("!").yellow().bold(),
+                    ),
+                    git::BranchDeleteOutcome::Failed(detail) => eprintln!(
+                        "{} removed worktree {branch} (branch delete failed: {detail})",
+                        style("!").yellow().bold(),
+                    ),
+                }
+            }
+            git::WorktreeRemoveOutcome::Failed(detail) => {
+                eprintln!(
+                    "{} failed to remove {}:",
+                    style("!").yellow().bold(),
+                    wt.path.display()
+                );
+                for line in detail.lines() {
+                    eprintln!("  {line}");
+                }
+            }
+        }
+    }
+
+    if cwd_will_vanish {
+        handoff_cd(&main.path);
+    }
+    Ok(())
+}
+
+/// Fetch + fast-forward `branch` in the worktree at `path`. Unlike the in-place
+/// switch, a diverged branch is only reported (we don't drive an interactive
+/// rebase in a worktree the user isn't sitting in).
+pub(crate) fn update_in(path: &Path, branch: &str, remote: &str) -> AppResult<()> {
+    match fetch_and_ff(Some(path), branch, remote)? {
+        git::FastForwardResult::Diverged => eprintln!(
+            "{} {} has diverged from {}/{}; not updating.",
+            style("!").yellow().bold(),
+            branch,
+            remote,
+            branch,
+        ),
+        git::FastForwardResult::Merged(report) => report_update(&report),
+    }
+    Ok(())
+}
+
+fn create_worktree(
+    main_path: &Path,
+    branch: &str,
+    base: Option<&str>,
+    remote: &str,
+) -> AppResult<PathBuf> {
+    let path = worktree_path_for(main_path, branch)?;
+    ensure_path_clear(&path)?;
+    ensure_parent(&path);
+
+    let result = {
+        let spinner = ProgressBar::new_spinner();
+        let _g = CursorGuard::hide();
+        spinner.enable_steady_tick(std::time::Duration::from_millis(80));
+        spinner.set_message(format!("Fetching {remote}…"));
+        let _ = git::fetch(None, remote);
+        spinner.set_message(format!("Creating worktree for {branch}…"));
+        let outcome = git::worktree_add(&path, branch, base);
+        spinner.finish_and_clear();
+        outcome
+    };
+    result?;
+
+    if let Some(base) = base {
+        eprintln!(
+            "{} created {} from {} at {}",
+            style("✓").green().bold(),
+            branch,
+            base,
+            path.display()
+        );
+    } else {
+        eprintln!(
+            "{} created worktree at {}",
+            style("✓").green().bold(),
+            path.display()
+        );
+    }
+    Ok(path)
+}
+
+fn select(
+    worktrees: &[git::Worktree],
+    current_branch: Option<&str>,
+    remote: &str,
+) -> AppResult<Option<Action>> {
+    let sections = build_wt_sections(worktrees, current_branch, remote)?;
+    let selection = pick(
+        current_branch,
+        &sections,
+        PickerOptions {
+            prompt: "Worktree",
+            allow_create_from_filter: true,
+        },
+    )?;
+    let action = match selection {
+        None => return Ok(None),
+        Some(Selection::Existing {
+            name,
+            kind: PickKind::Worktree,
+        }) => git::worktree_for_branch(worktrees, &name)
+            .map(Action::CdToExisting)
+            .unwrap_or(Action::CreateForBranch(name)),
+        Some(Selection::Existing {
+            name,
+            kind: PickKind::Branch,
+        }) => Action::CreateForBranch(name),
+        Some(Selection::Create(name)) => Action::CreateNewBranch(name),
+    };
+    Ok(Some(action))
+}
+
+fn build_wt_sections(
+    worktrees: &[git::Worktree],
+    current_branch: Option<&str>,
+    remote: &str,
+) -> AppResult<Vec<Section>> {
+    let held: HashSet<String> = worktrees.iter().filter_map(|w| w.branch.clone()).collect();
+
+    let mut wt_picks: Vec<Pick> = worktrees
+        .iter()
+        .filter_map(|w| {
+            w.branch.as_ref().map(|b| Pick {
+                name: b.clone(),
+                is_current: current_branch == Some(b.as_str()),
+                availability: Availability::Local,
+                kind: PickKind::Worktree,
+            })
+        })
+        .collect();
+    wt_picks.sort_by(|a, b| a.name.cmp(&b.name));
+
+    let mut sections = Vec::new();
+    if !wt_picks.is_empty() {
+        sections.push(Section {
+            heading: "Worktrees",
+            items: wt_picks,
+        });
+    }
+    sections.extend(build_sections(current_branch, remote, &held)?);
+    Ok(sections)
+}
+
+fn resolve_target(name: &str, worktrees: &[git::Worktree], remote: &str) -> AppResult<Action> {
+    if let Some(wt) = git::worktree_for_branch(worktrees, name) {
+        return Ok(Action::CdToExisting(wt));
+    }
+    let locals = git::local_branches()?;
+    if locals.iter().any(|b| b == name) {
+        return Ok(Action::CreateForBranch(name.to_string()));
+    }
+    let remote_only = git::remote_only_branches(&locals, remote).unwrap_or_default();
+    if remote_only.iter().any(|b| b == name) {
+        return Ok(Action::CreateForBranch(name.to_string()));
+    }
+    Ok(Action::CreateNewBranch(name.to_string()))
+}
+
+fn main_of(worktrees: &[git::Worktree]) -> AppResult<&git::Worktree> {
+    worktrees
+        .iter()
+        .find(|w| w.is_main)
+        .ok_or_else(|| Error::Git {
+            command: "worktree list".into(),
+            message: "no main worktree found".into(),
+        })
+}
+
+fn worktree_path_for(main_path: &Path, branch: &str) -> AppResult<PathBuf> {
+    let parent = main_path.parent().ok_or_else(|| Error::Git {
+        command: "worktree".into(),
+        message: format!("main worktree has no parent: {}", main_path.display()),
+    })?;
+    let repo_name = main_path.file_name().ok_or_else(|| Error::Git {
+        command: "worktree".into(),
+        message: format!("cannot determine repo name from {}", main_path.display()),
+    })?;
+    Ok(parent.join("worktrees").join(repo_name).join(branch))
+}
+
+fn ensure_path_clear(path: &Path) -> AppResult<()> {
+    if path.exists() {
+        return Err(Error::Git {
+            command: "worktree add".into(),
+            message: format!(
+                "{} exists but is not a registered worktree; remove it manually and retry.",
+                path.display()
+            ),
+        });
+    }
+    Ok(())
+}
+
+fn ensure_parent(path: &Path) {
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+}

--- a/src/app/wt.rs
+++ b/src/app/wt.rs
@@ -196,6 +196,9 @@ pub(crate) fn update_in(path: &Path, branch: &str, remote: &str) -> AppResult<()
             remote,
             branch,
         ),
+        // A worktree branch with no upstream is unremarkable here — unlike the
+        // in-place switch, stay quiet rather than printing "No remote…".
+        git::FastForwardResult::Merged(git::MergeReport::NoRemote) => {}
         git::FastForwardResult::Merged(report) => report_update(&report),
     }
     Ok(())

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use crate::{AppResult, Error};
@@ -145,8 +146,8 @@ pub fn checkout(branch: &str) -> AppResult<()> {
     Ok(())
 }
 
-pub fn fetch(remote: &str) -> AppResult<FetchOutcome> {
-    let output = Command::new("git")
+pub fn fetch(dir: Option<&Path>, remote: &str) -> AppResult<FetchOutcome> {
+    let output = git_cmd(dir)
         .args(["fetch", "--quiet", "--prune", remote])
         .output()?;
     if output.status.success() {
@@ -175,10 +176,14 @@ pub fn rebase(onto: &str) -> AppResult<RebaseOutcome> {
     Ok(RebaseOutcome::Aborted)
 }
 
-pub fn fast_forward_merge(branch: &str, remote: &str) -> AppResult<FastForwardResult> {
+pub fn fast_forward_merge(
+    dir: Option<&Path>,
+    branch: &str,
+    remote: &str,
+) -> AppResult<FastForwardResult> {
     let remote_ref = format!("{remote}/{branch}");
 
-    let has_remote = Command::new("git")
+    let has_remote = git_cmd(dir)
         .args(["rev-parse", "--verify", &remote_ref])
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
@@ -189,11 +194,11 @@ pub fn fast_forward_merge(branch: &str, remote: &str) -> AppResult<FastForwardRe
         return Ok(FastForwardResult::Merged(MergeReport::NoRemote));
     }
 
-    let before = rev_parse("HEAD")?;
+    let before = rev_parse(dir, "HEAD")?;
 
     // Capture stderr so git's diverging hint and "fatal: Not possible to
     // fast-forward" don't leak — we surface a tailored message instead.
-    let output = Command::new("git")
+    let output = git_cmd(dir)
         .args([
             "-c",
             "advice.diverging=false",
@@ -208,13 +213,13 @@ pub fn fast_forward_merge(branch: &str, remote: &str) -> AppResult<FastForwardRe
         return Ok(FastForwardResult::Diverged);
     }
 
-    let after = rev_parse("HEAD")?;
+    let after = rev_parse(dir, "HEAD")?;
 
     if before == after {
         return Ok(FastForwardResult::Merged(MergeReport::UpToDate));
     }
 
-    let output = run(&["rev-list", "--count", &format!("{before}..{after}")])?;
+    let output = run_in(dir, &["rev-list", "--count", &format!("{before}..{after}")])?;
     let count: u32 = output.trim().parse()?;
     Ok(FastForwardResult::Merged(MergeReport::Pulled(count)))
 }
@@ -250,7 +255,7 @@ pub fn stale_branches(remote: &str) -> AppResult<Vec<String>> {
         }
     }
 
-    let head = rev_parse("HEAD")?;
+    let head = rev_parse(None, "HEAD")?;
 
     let mut branches: Vec<String> = merged_output
         .lines()
@@ -295,7 +300,8 @@ pub fn pinned_branches(remote: &str) -> Vec<String> {
     out
 }
 
-fn default_branch(remote: &str) -> Option<String> {
+#[must_use]
+pub(crate) fn default_branch(remote: &str) -> Option<String> {
     let head_ref = format!("refs/remotes/{remote}/HEAD");
     let prefix = format!("refs/remotes/{remote}/");
     if let Ok(output) = run(&["symbolic-ref", &head_ref]) {
@@ -317,16 +323,111 @@ fn kept_branches(remote: &str) -> HashSet<String> {
     kept
 }
 
+/// Detached worktrees have `branch: None`.
+#[derive(Debug, Clone)]
+pub struct Worktree {
+    pub path: PathBuf,
+    pub branch: Option<String>,
+    pub is_main: bool,
+}
+
+/// Lists all worktrees for the current repo. Per `git worktree list
+/// --porcelain`, the first record is the main worktree.
+pub fn worktree_list() -> AppResult<Vec<Worktree>> {
+    let output = run(&["worktree", "list", "--porcelain"])?;
+    let mut worktrees: Vec<Worktree> = Vec::new();
+    let mut path: Option<PathBuf> = None;
+    let mut branch: Option<String> = None;
+
+    let flush =
+        |worktrees: &mut Vec<Worktree>, path: &mut Option<PathBuf>, branch: &mut Option<String>| {
+            if let Some(p) = path.take() {
+                let is_main = worktrees.is_empty();
+                worktrees.push(Worktree {
+                    path: p,
+                    branch: branch.take(),
+                    is_main,
+                });
+            }
+        };
+
+    for line in output.lines() {
+        if line.is_empty() {
+            flush(&mut worktrees, &mut path, &mut branch);
+        } else if let Some(p) = line.strip_prefix("worktree ") {
+            flush(&mut worktrees, &mut path, &mut branch);
+            path = Some(PathBuf::from(p));
+        } else if let Some(b) = line.strip_prefix("branch refs/heads/") {
+            branch = Some(b.to_string());
+        }
+    }
+    flush(&mut worktrees, &mut path, &mut branch);
+    Ok(worktrees)
+}
+
 /// Branches currently checked out in any worktree (including the main one).
 /// These cannot be deleted with `git branch -D`.
 pub fn worktree_branches() -> AppResult<HashSet<String>> {
-    let output = run(&["worktree", "list", "--porcelain"])?;
-    let branches = output
-        .lines()
-        .filter_map(|l| l.strip_prefix("branch refs/heads/"))
-        .map(String::from)
-        .collect();
-    Ok(branches)
+    Ok(worktree_list()?
+        .into_iter()
+        .filter_map(|w| w.branch)
+        .collect())
+}
+
+#[must_use]
+pub fn worktree_for_branch(worktrees: &[Worktree], branch: &str) -> Option<Worktree> {
+    worktrees
+        .iter()
+        .find(|w| w.branch.as_deref() == Some(branch))
+        .cloned()
+}
+
+/// Add a worktree at `path` for `branch`. If `base` is `Some`, create the
+/// branch from `base` (e.g. `origin/main`); if `None`, check out an existing
+/// local or remote-tracking branch.
+pub fn worktree_add(path: &Path, branch: &str, base: Option<&str>) -> AppResult<()> {
+    let path_str = path_to_str(path)?;
+    let output = if let Some(base) = base {
+        Command::new("git")
+            .args(["worktree", "add", "-b", branch, path_str, base])
+            .output()?
+    } else {
+        Command::new("git")
+            .args(["worktree", "add", path_str, branch])
+            .output()?
+    };
+    if output.status.success() {
+        return Ok(());
+    }
+    Err(Error::Git {
+        command: "worktree add".to_string(),
+        message: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+    })
+}
+
+pub enum WorktreeRemoveOutcome {
+    Removed,
+    Failed(String),
+}
+
+pub fn worktree_remove(path: &Path) -> AppResult<WorktreeRemoveOutcome> {
+    let path_str = path_to_str(path)?;
+    let output = Command::new("git")
+        .args(["worktree", "remove", path_str])
+        .output()?;
+    if output.status.success() {
+        return Ok(WorktreeRemoveOutcome::Removed);
+    }
+    Ok(WorktreeRemoveOutcome::Failed(
+        String::from_utf8_lossy(&output.stderr).trim().to_string(),
+    ))
+}
+
+fn path_to_str(path: &Path) -> AppResult<&str> {
+    path.to_str().ok_or_else(|| Error::Git {
+        command: "worktree".to_string(),
+        message: format!("non-utf8 path: {}", path.display()),
+    })
 }
 
 pub fn delete_branches(branches: &[&str]) -> AppResult<()> {
@@ -334,6 +435,30 @@ pub fn delete_branches(branches: &[&str]) -> AppResult<()> {
     args.extend(branches);
     run(&args)?;
     Ok(())
+}
+
+pub enum BranchDeleteOutcome {
+    Deleted,
+    /// Kept because it has commits not merged into its upstream or HEAD.
+    NotMerged,
+    Failed(String),
+}
+
+/// Delete `branch` only if git considers it fully merged (`git branch -d`).
+/// Unlike [`delete_branches`] this never force-deletes, so unmerged work is
+/// preserved rather than silently discarded.
+pub fn delete_branch_if_merged(branch: &str) -> AppResult<BranchDeleteOutcome> {
+    let output = git_cmd(None)
+        .args(["branch", "-d", "--quiet", branch])
+        .output()?;
+    if output.status.success() {
+        return Ok(BranchDeleteOutcome::Deleted);
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if stderr.contains("not fully merged") {
+        return Ok(BranchDeleteOutcome::NotMerged);
+    }
+    Ok(BranchDeleteOutcome::Failed(stderr.trim().to_string()))
 }
 
 /// Returns true if the branch had unique commits that were merged, not just a
@@ -353,13 +478,27 @@ fn has_unique_commits(branch: &str, tip: &str, head: &str) -> bool {
     tip == head
 }
 
-fn rev_parse(refname: &str) -> AppResult<String> {
-    let output = run(&["rev-parse", refname])?;
+fn rev_parse(dir: Option<&Path>, refname: &str) -> AppResult<String> {
+    let output = run_in(dir, &["rev-parse", refname])?;
     Ok(output.trim().to_string())
 }
 
+/// A `git` command, optionally rooted in `dir` via `-C` so it operates on
+/// another worktree without mutating the process's working directory.
+fn git_cmd(dir: Option<&Path>) -> Command {
+    let mut cmd = Command::new("git");
+    if let Some(d) = dir {
+        cmd.arg("-C").arg(d);
+    }
+    cmd
+}
+
 fn run(args: &[&str]) -> AppResult<String> {
-    let output = Command::new("git").args(args).output()?;
+    run_in(None, args)
+}
+
+fn run_in(dir: Option<&Path>, args: &[&str]) -> AppResult<String> {
+    let output = git_cmd(dir).args(args).output()?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         return Err(Error::Git {

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,20 +6,10 @@ fn main() {
         process::exit(130);
     });
 
-    let target = match std::env::args().nth(1).as_deref() {
-        Some("--help" | "-h") => {
-            println!("Usage: git-switch [<branch>]");
-            return;
-        }
-        Some("--version" | "-V") => {
-            println!("git-switch {}", env!("CARGO_PKG_VERSION"));
-            return;
-        }
-        Some(name) => Some(name.to_string()),
-        None => None,
-    };
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let result = dispatch(&args);
 
-    if let Err(e) = git_switch::app::run(target.as_deref()) {
+    if let Err(e) = result {
         if let git_switch::Error::Io(io) = &e
             && io.kind() == std::io::ErrorKind::Interrupted
         {
@@ -29,4 +19,50 @@ fn main() {
         eprintln!("error: {e}");
         process::exit(1);
     }
+}
+
+fn dispatch(args: &[String]) -> git_switch::AppResult<()> {
+    match args.first().map(String::as_str) {
+        Some("--help" | "-h") => {
+            print_help();
+            Ok(())
+        }
+        Some("--version" | "-V") => {
+            println!("git-switch {}", env!("CARGO_PKG_VERSION"));
+            Ok(())
+        }
+        // `--` ends option/subcommand parsing: everything after is a branch,
+        // so a branch literally named `wt`/`worktree` stays reachable.
+        Some("--") => git_switch::app::run(args.get(1).map(String::as_str)),
+        Some("wt" | "worktree") => dispatch_wt(&args[1..]),
+        Some(name) => git_switch::app::run(Some(name)),
+        None => git_switch::app::run(None),
+    }
+}
+
+fn dispatch_wt(args: &[String]) -> git_switch::AppResult<()> {
+    match args.first().map(String::as_str) {
+        Some("--help" | "-h") => {
+            print_wt_help();
+            Ok(())
+        }
+        Some("ls" | "list") => git_switch::app::wt::run_ls(),
+        Some("rm" | "remove") => git_switch::app::wt::run_rm(args.get(1).map(String::as_str)),
+        Some(name) => git_switch::app::wt::run(Some(name)),
+        None => git_switch::app::wt::run(None),
+    }
+}
+
+fn print_help() {
+    println!("Usage: git-switch [<branch>]");
+    println!("       git-switch -- <branch>     Switch to a branch named wt/worktree");
+    println!("       git-switch wt [<branch>]");
+    println!("       git-switch wt ls");
+    println!("       git-switch wt rm [<branch>]");
+}
+
+fn print_wt_help() {
+    println!("Usage: git-switch wt [<branch>]    Switch to or create a worktree");
+    println!("       git-switch wt ls            List worktrees");
+    println!("       git-switch wt rm [<branch>] Remove a worktree (deletes branch if merged)");
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -994,3 +994,36 @@ fn handoff_fast_forwards_held_worktree_from_its_own_remote() {
         .to_string();
     assert_eq!(head, upstream, "worktree HEAD should be fast-forwarded");
 }
+
+#[test]
+fn wt_rm_reports_failure_and_keeps_branch_when_worktree_is_dirty() {
+    let (_bare, parent, work) = setup_with_parent();
+
+    git(&work, &["branch", "feature"]);
+    let path = parent.path().join("worktrees").join("repo").join("feature");
+    git(
+        &work,
+        &["worktree", "add", path.to_str().unwrap(), "feature"],
+    );
+
+    // An untracked file makes `git worktree remove` refuse without --force.
+    fs::write(path.join("dirty.txt"), "uncommitted\n").unwrap();
+
+    let output = git_switch_args(&work, &["wt", "rm", "feature"]);
+    // The command itself succeeds (per-worktree failures are reported, not fatal).
+    assert!(output.status.success(), "stderr: {}", stderr_str(&output));
+    assert!(
+        stderr_str(&output).contains("failed to remove"),
+        "should report the removal failure; stderr: {}",
+        stderr_str(&output)
+    );
+
+    // Nothing was destroyed: the worktree dir survives and the branch remains.
+    assert!(path.exists(), "worktree dir should still exist on failure");
+    let branches = git(&work, &["branch", "--format=%(refname:short)"]);
+    assert!(
+        stdout_str(&branches).lines().any(|l| l == "feature"),
+        "branch must not be deleted when removal failed; got: {}",
+        stdout_str(&branches)
+    );
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -926,3 +926,71 @@ fn double_dash_switches_to_branch_named_like_subcommand() {
     let head = git(work.path(), &["branch", "--show-current"]);
     assert_eq!(stdout_str(&head).trim(), "wt");
 }
+
+#[test]
+fn wt_rm_from_inside_doomed_worktree_hands_off_to_main() {
+    let (_bare, parent, work) = setup_with_parent();
+
+    git(&work, &["branch", "feature"]);
+    let path = parent.path().join("worktrees").join("repo").join("feature");
+    git(
+        &work,
+        &["worktree", "add", path.to_str().unwrap(), "feature"],
+    );
+
+    // Run `wt rm feature` *from inside* the worktree being removed: cwd would
+    // vanish, so it must chdir to main and hand that path off for the wrapper.
+    let output = git_switch_args(&path, &["wt", "rm", "feature"]);
+    assert!(output.status.success(), "stderr: {}", stderr_str(&output));
+    assert!(!path.exists(), "worktree dir should be removed");
+
+    let printed = stdout_str(&output).trim().to_string();
+    assert!(
+        Path::new(&printed).is_dir() && printed.ends_with("repo"),
+        "stdout should be the main worktree path; got: {printed}"
+    );
+}
+
+#[test]
+fn handoff_fast_forwards_held_worktree_from_its_own_remote() {
+    let (_bare, parent, work) = setup_with_parent();
+
+    let path = parent.path().join("worktrees").join("repo").join("feature");
+    git(
+        &work,
+        &[
+            "worktree",
+            "add",
+            "-b",
+            "feature",
+            path.to_str().unwrap(),
+            "main",
+        ],
+    );
+
+    // Publish a commit on `feature`, record it, then rewind the worktree so it
+    // sits one commit behind its upstream.
+    fs::write(path.join("f.txt"), "v1\n").unwrap();
+    git(&path, &["add", "f.txt"]);
+    git(&path, &["commit", "-m", "remote work"]);
+    git(&path, &["push", "-u", "origin", "feature"]);
+    let upstream = stdout_str(&git(&path, &["rev-parse", "HEAD"]))
+        .trim()
+        .to_string();
+    git(&path, &["reset", "--hard", "HEAD~1"]);
+
+    // Plain `git-switch feature` from main: hands off and updates the worktree.
+    let output = git_switch(&work, "feature");
+    assert!(output.status.success(), "stderr: {}", stderr_str(&output));
+    assert!(
+        stderr_str(&output).contains("Pulled 1 commit"),
+        "should fast-forward the held worktree; stderr: {}",
+        stderr_str(&output)
+    );
+
+    // The worktree (not the main checkout) must now be at the upstream commit.
+    let head = stdout_str(&git(&path, &["rev-parse", "HEAD"]))
+        .trim()
+        .to_string();
+    assert_eq!(head, upstream, "worktree HEAD should be fast-forwarded");
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -778,6 +778,12 @@ fn wt_cd_to_existing_worktree_prints_path() {
         printed.ends_with("worktrees/repo/feature") && Path::new(&printed).is_dir(),
         "stdout should be the existing worktree path; got: {printed}"
     );
+    // A worktree branch without an upstream must not emit "No remote…" noise.
+    assert!(
+        !stderr_str(&output).contains("No remote"),
+        "cd to a worktree should stay quiet about missing upstream; got: {}",
+        stderr_str(&output)
+    );
 }
 
 #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -56,12 +56,44 @@ fn git(dir: &Path, args: &[&str]) -> Output {
     output
 }
 
-fn git_switch(dir: &Path, branch: &str) -> Output {
+fn git_switch_args(dir: &Path, args: &[&str]) -> Output {
     Command::new(env!("CARGO_BIN_EXE_git-switch"))
-        .arg(branch)
+        .args(args)
         .current_dir(dir)
         .output()
         .expect("failed to run git-switch")
+}
+
+fn git_switch(dir: &Path, branch: &str) -> Output {
+    git_switch_args(dir, &[branch])
+}
+
+/// Like `setup`, but places the working clone inside a parent `TempDir` so
+/// worktrees created at `<parent>/worktrees/<repo>/...` land in cleanable
+/// space. Returns `(bare, parent, work_path)`.
+fn setup_with_parent() -> (TempDir, TempDir, PathBuf) {
+    let bare = TempDir::new().unwrap();
+    let parent = TempDir::new().unwrap();
+    let work = parent.path().join("repo");
+    fs::create_dir(&work).unwrap();
+
+    git(bare.path(), &["init", "--bare"]);
+
+    git(&work, &["init", "-b", "main"]);
+    git(&work, &["config", "user.name", "test"]);
+    git(&work, &["config", "user.email", "test@example.com"]);
+    git(
+        &work,
+        &["remote", "add", "origin", bare.path().to_str().unwrap()],
+    );
+
+    fs::write(work.join("file.txt"), "hello\n").unwrap();
+    git(&work, &["add", "file.txt"]);
+    git(&work, &["commit", "-m", "initial"]);
+    git(&work, &["push", "-u", "origin", "main"]);
+    git(&work, &["remote", "set-head", "origin", "main"]);
+
+    (bare, parent, work)
 }
 
 /// Create a bare "remote" and a working clone with one commit on `main`.
@@ -141,9 +173,9 @@ fn fast_forward_pull() {
 
     assert!(output.status.success(), "stderr: {}", stderr_str(&output));
     assert!(
-        stdout_str(&output).contains("Pulled 1 commit"),
-        "stdout: {}",
-        stdout_str(&output)
+        stderr_str(&output).contains("Pulled 1 commit"),
+        "stderr: {}",
+        stderr_str(&output)
     );
 
     let content = fs::read_to_string(work.path().join("file.txt")).unwrap();
@@ -169,9 +201,9 @@ fn auto_stash_and_restore() {
 
     assert!(output.status.success(), "stderr: {}", stderr_str(&output));
     assert!(
-        stdout_str(&output).contains("Pulled 1 commit"),
-        "stdout: {}",
-        stdout_str(&output)
+        stderr_str(&output).contains("Pulled 1 commit"),
+        "stderr: {}",
+        stderr_str(&output)
     );
 
     // Local modification must survive the round-trip.
@@ -418,6 +450,10 @@ fn help_flag_prints_usage() {
         out.contains("Usage: git-switch"),
         "expected usage line, got: {out}"
     );
+    assert!(
+        out.contains("git-switch wt"),
+        "expected worktree usage in help, got: {out}"
+    );
 }
 
 #[test]
@@ -448,9 +484,9 @@ fn non_origin_remote_pulls_via_branch_config() {
 
     assert!(output.status.success(), "stderr: {}", stderr_str(&output));
     assert!(
-        stdout_str(&output).contains("Pulled 1 commit"),
-        "stdout: {}",
-        stdout_str(&output)
+        stderr_str(&output).contains("Pulled 1 commit"),
+        "stderr: {}",
+        stderr_str(&output)
     );
 
     let content = fs::read_to_string(work.path().join("file.txt")).unwrap();
@@ -643,4 +679,250 @@ fn detached_head_can_switch_to_branch() {
 
     let head = git(work.path(), &["branch", "--show-current"]);
     assert_eq!(stdout_str(&head).trim(), "main");
+}
+
+#[test]
+fn wt_creates_worktree_for_existing_local_branch() {
+    let (_bare, parent, work) = setup_with_parent();
+
+    git(&work, &["branch", "feature"]);
+
+    let output = git_switch_args(&work, &["wt", "feature"]);
+    assert!(output.status.success(), "stderr: {}", stderr_str(&output));
+
+    let expected = parent.path().join("worktrees").join("repo").join("feature");
+    assert!(
+        expected.exists(),
+        "worktree should exist at {}",
+        expected.display()
+    );
+    assert!(
+        stdout_str(&output).trim().ends_with("repo/feature"),
+        "stdout should be the worktree path; got: {}",
+        stdout_str(&output)
+    );
+
+    let list = git(&work, &["worktree", "list", "--porcelain"]);
+    let s = stdout_str(&list);
+    assert!(
+        s.contains("branch refs/heads/feature"),
+        "expected `feature` worktree; got: {s}"
+    );
+}
+
+#[test]
+fn wt_creates_new_branch_from_default_when_branch_absent() {
+    let (_bare, parent, work) = setup_with_parent();
+
+    let output = git_switch_args(&work, &["wt", "brand-new"]);
+    assert!(output.status.success(), "stderr: {}", stderr_str(&output));
+
+    let expected = parent
+        .path()
+        .join("worktrees")
+        .join("repo")
+        .join("brand-new");
+    assert!(
+        expected.exists(),
+        "worktree should exist at {}",
+        expected.display()
+    );
+
+    // The new branch should have a base commit (from origin/main).
+    let head = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(&expected)
+        .output()
+        .unwrap();
+    assert!(head.status.success(), "stderr: {}", stderr_str(&head));
+}
+
+#[test]
+fn wt_preserves_slashes_as_subdirs() {
+    let (_bare, parent, work) = setup_with_parent();
+
+    git(&work, &["branch", "feature/nested"]);
+
+    let output = git_switch_args(&work, &["wt", "feature/nested"]);
+    assert!(output.status.success(), "stderr: {}", stderr_str(&output));
+
+    let expected = parent
+        .path()
+        .join("worktrees")
+        .join("repo")
+        .join("feature")
+        .join("nested");
+    assert!(
+        expected.exists(),
+        "nested worktree should exist at {}",
+        expected.display()
+    );
+}
+
+#[test]
+fn wt_cd_to_existing_worktree_prints_path() {
+    let (_bare, parent, work) = setup_with_parent();
+
+    git(&work, &["branch", "feature"]);
+    let path = parent.path().join("worktrees").join("repo").join("feature");
+    git(
+        &work,
+        &["worktree", "add", path.to_str().unwrap(), "feature"],
+    );
+
+    let output = git_switch_args(&work, &["wt", "feature"]);
+    assert!(output.status.success(), "stderr: {}", stderr_str(&output));
+
+    let printed = stdout_str(&output).trim().to_string();
+    assert!(
+        printed.ends_with("worktrees/repo/feature") && Path::new(&printed).is_dir(),
+        "stdout should be the existing worktree path; got: {printed}"
+    );
+}
+
+#[test]
+fn wt_refuses_when_target_path_is_stale_non_worktree_directory() {
+    let (_bare, parent, work) = setup_with_parent();
+
+    git(&work, &["branch", "feature"]);
+    let stale = parent.path().join("worktrees").join("repo").join("feature");
+    fs::create_dir_all(&stale).unwrap();
+    fs::write(stale.join("leftover.txt"), "junk").unwrap();
+
+    let output = git_switch_args(&work, &["wt", "feature"]);
+    assert!(!output.status.success());
+
+    let combined = format!("{}{}", stdout_str(&output), stderr_str(&output));
+    assert!(
+        combined.contains("exists but is not a registered worktree"),
+        "expected stale-dir error; got: {combined}"
+    );
+}
+
+#[test]
+fn wt_ls_lists_all_worktrees() {
+    let (_bare, parent, work) = setup_with_parent();
+
+    git(&work, &["branch", "feature"]);
+    let path = parent.path().join("worktrees").join("repo").join("feature");
+    git(
+        &work,
+        &["worktree", "add", path.to_str().unwrap(), "feature"],
+    );
+
+    let output = git_switch_args(&work, &["wt", "ls"]);
+    assert!(output.status.success(), "stderr: {}", stderr_str(&output));
+
+    let out = stdout_str(&output);
+    assert!(out.contains("main"), "ls should mention main; got: {out}");
+    assert!(
+        out.contains("feature"),
+        "ls should mention feature; got: {out}"
+    );
+}
+
+#[test]
+fn wt_rm_removes_worktree_and_deletes_branch() {
+    let (_bare, parent, work) = setup_with_parent();
+
+    git(&work, &["branch", "feature"]);
+    let path = parent.path().join("worktrees").join("repo").join("feature");
+    git(
+        &work,
+        &["worktree", "add", path.to_str().unwrap(), "feature"],
+    );
+
+    let output = git_switch_args(&work, &["wt", "rm", "feature"]);
+    assert!(output.status.success(), "stderr: {}", stderr_str(&output));
+
+    assert!(
+        !path.exists(),
+        "worktree dir should be removed: {}",
+        path.display()
+    );
+
+    let branches = git(&work, &["branch", "--format=%(refname:short)"]);
+    assert!(
+        !stdout_str(&branches).lines().any(|l| l == "feature"),
+        "branch should be deleted; got: {}",
+        stdout_str(&branches)
+    );
+}
+
+#[test]
+fn in_place_switch_hands_off_when_branch_is_held_by_worktree() {
+    let (_bare, parent, work) = setup_with_parent();
+
+    git(&work, &["branch", "feature"]);
+    let path = parent.path().join("worktrees").join("repo").join("feature");
+    git(
+        &work,
+        &["worktree", "add", path.to_str().unwrap(), "feature"],
+    );
+
+    // Plain `git-switch feature` from main worktree: branch is held → handoff.
+    let output = git_switch(&work, "feature");
+    assert!(output.status.success(), "stderr: {}", stderr_str(&output));
+
+    let printed = stdout_str(&output).trim().to_string();
+    assert!(
+        printed.ends_with("worktrees/repo/feature") && Path::new(&printed).is_dir(),
+        "stdout should be the worktree path for the shell wrapper; got: {printed}"
+    );
+
+    // Original worktree's HEAD must NOT have changed (no checkout happened).
+    let head = git(&work, &["branch", "--show-current"]);
+    assert_eq!(stdout_str(&head).trim(), "main");
+}
+
+#[test]
+fn wt_rm_keeps_branch_with_unmerged_commits() {
+    let (_bare, parent, work) = setup_with_parent();
+
+    git(&work, &["branch", "feature"]);
+    let path = parent.path().join("worktrees").join("repo").join("feature");
+    git(
+        &work,
+        &["worktree", "add", path.to_str().unwrap(), "feature"],
+    );
+
+    // A commit on `feature` that never lands on main → not fully merged.
+    fs::write(path.join("new.txt"), "unmerged\n").unwrap();
+    git(&path, &["add", "new.txt"]);
+    git(&path, &["commit", "-m", "unmerged work"]);
+
+    let output = git_switch_args(&work, &["wt", "rm", "feature"]);
+    assert!(output.status.success(), "stderr: {}", stderr_str(&output));
+
+    assert!(
+        !path.exists(),
+        "worktree dir should be removed: {}",
+        path.display()
+    );
+
+    // Branch must survive, since -d refuses to drop unmerged commits.
+    let branches = git(&work, &["branch", "--format=%(refname:short)"]);
+    assert!(
+        stdout_str(&branches).lines().any(|l| l == "feature"),
+        "branch should be kept; got: {}",
+        stdout_str(&branches)
+    );
+    assert!(
+        stderr_str(&output).contains("unmerged"),
+        "should warn about unmerged commits; got: {}",
+        stderr_str(&output)
+    );
+}
+
+#[test]
+fn double_dash_switches_to_branch_named_like_subcommand() {
+    let (_bare, work) = setup();
+
+    git(work.path(), &["branch", "wt"]);
+
+    let output = git_switch_args(work.path(), &["--", "wt"]);
+    assert!(output.status.success(), "stderr: {}", stderr_str(&output));
+
+    let head = git(work.path(), &["branch", "--show-current"]);
+    assert_eq!(stdout_str(&head).trim(), "wt");
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -931,6 +931,16 @@ fn double_dash_switches_to_branch_named_like_subcommand() {
 
     let head = git(work.path(), &["branch", "--show-current"]);
     assert_eq!(stdout_str(&head).trim(), "wt");
+
+    // Switching off `main` makes it a stale merged branch, which triggers the
+    // delete prompt. Non-interactively that must neither block nor act: `main`
+    // must survive (regression guard for the multi_select TTY check).
+    let branches = git(work.path(), &["branch", "--format=%(refname:short)"]);
+    assert!(
+        stdout_str(&branches).lines().any(|l| l == "main"),
+        "main must not be auto-deleted in a non-interactive run; got: {}",
+        stdout_str(&branches)
+    );
 }
 
 #[test]


### PR DESCRIPTION
## What changed
Adds a `git-switch wt` command to create, switch into, list, and remove git worktrees. `wt <branch>` is DWIM — it switches into the worktree holding a branch, creates one for an existing branch, or creates a brand-new branch off the remote's default. Plain `git-switch <branch>` now hands off to an existing worktree instead of failing with git's "already checked out" error.

Because a child process can't change its parent shell's directory, worktree commands print their target path on stdout and a small bash/zsh/fish wrapper (installed via `just install-shell-integration`) runs the `cd`. Tab completion covers the new subcommands.

## Things to look out for
- **Shell contract:** stdout is now reserved for the cd-handoff path; all status output moved to stderr. Without the sourced wrapper, `wt` still works and just prints the path for a manual `cd`.
- **`wt rm` deletes the branch** only when it's fully merged (`git branch -d`); branches with unmerged commits are kept and reported, never force-deleted.
- **Remote handling:** worktree fetch/fast-forward uses the *target* branch's own remote, and runs via `git -C <path>` rather than mutating the process cwd.
- **`--` escape:** `git-switch -- wt` reaches a branch literally named `wt`/`worktree`, which the subcommand keywords would otherwise shadow.

## Test plan
- [x] `just test` — 33 integration tests pass (drive the real binary against temp git repos: create/switch/ls/rm, cd hand-off, cwd-vanish, held-worktree fast-forward, dirty-worktree failure, `--` escape)
- [x] `cargo clippy --all-targets` clean
- [x] Interactive pickers (`wt` no-arg, `wt rm` multi-select) — not automatable without a TTY; worth a manual spin